### PR TITLE
Expose all picoFeed errors to the Frontend when adding a subscription

### DIFF
--- a/controllers/feed.php
+++ b/controllers/feed.php
@@ -159,17 +159,50 @@ Router\action('subscribe', function() {
     }
 
     $values += array('url' => trim($url), 'download_content' => 0, 'rtl' => 0, 'cloak_referrer' => 0);
-    $feed_id = Model\Feed\create($values['url'], $values['download_content'], $values['rtl'], $values['cloak_referrer']);
 
-    if ($feed_id > 0) {
+    try {
+        $feed_id = Model\Feed\create($values['url'], $values['download_content'], $values['rtl'], $values['cloak_referrer']);
+    }
+    catch (UnexpectedValueException $e) {
+        $error_message = t('This subscription already exists.');
+    }
+    catch (PicoFeed\Client\InvalidCertificateException $e) {
+        $error_message = t('Invalid SSL certificate.');
+    }
+    catch (PicoFeed\Client\InvalidUrlException $e) {
+        // picoFeed uses this exception for multiple reasons, but doesn't
+        // provide an exception code to distinguish what exactly happend here
+        $error_message = $e->getMessage();
+    }
+    catch (PicoFeed\Client\MaxRedirectException $e) {
+        $error_message = t('Maximum number of HTTP redirections exceeded.');
+    }
+    catch (PicoFeed\Client\MaxSizeException $e) {
+        $error_message = t('The content size exceeds to maximum allowed size.');
+    }
+    catch (PicoFeed\Client\TimeoutException $e) {
+        $error_message = t('Connection timeout.');
+    }
+    catch (PicoFeed\Parser\MalformedXmlException $e) {
+        $error_message = t('Feed is malformed.');
+    }
+    catch (PicoFeed\Reader\SubscriptionNotFoundException $e) {
+        $error_message = t('Unable to find a subscription.');
+    }
+    catch (PicoFeed\Reader\UnsupportedFeedFormatException $e) {
+        $error_message = t('Unable to detect the feed format.');
+    }
+
+    if (isset($feed_id) && $feed_id !== false) {
         Session\flash(t('Subscription added successfully.'));
         Response\redirect('?action=feed-items&feed_id='.$feed_id);
     }
-    else if ($feed_id === -2) {
-        Session\flash_error(t('This subscription already exists.'));
-    }
     else {
-        Session\flash_error(t('Unable to find a subscription.'));
+        if (! isset($error_message)) {
+            $error_message = t('Error occured.');
+        }
+
+        Session\flash_error($error_message);
     }
 
     Response\html(Template\layout('add', array(

--- a/jsonrpc.php
+++ b/jsonrpc.php
@@ -3,6 +3,7 @@
 require __DIR__.'/common.php';
 
 use JsonRPC\Server;
+use PicoFeed\PicoFeedException;
 
 $server = new Server;
 $server->authentication(array(
@@ -24,7 +25,16 @@ $server->register('feed.info', function ($feed_id) {
 // Add a new feed
 $server->register('feed.create', function($url) {
 
-    $result = Model\Feed\create($url);
+    try {
+        $result = Model\Feed\create($url);
+    }
+    catch (PicoFeedException $e) {
+        $result = false;
+    }
+    catch (UnexpectedValueException $e) {
+        $result = false;
+    }
+
     Model\Config\write_debug();
 
     return $result;

--- a/locales/ar_AR/translations.php
+++ b/locales/ar_AR/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'تحويل العنوان إلى مقروء بمجرد النقر على الرابط الأصلي للعنوان',
     'Cloak the image referrer' => 'Cloak the image referrer',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/cs_CZ/translations.php
+++ b/locales/cs_CZ/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'Původní odkaz označí článek za přečtený',
     'Cloak the image referrer' => 'Zamaskovat původce obrázků',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/de_DE/translations.php
+++ b/locales/de_DE/translations.php
@@ -231,4 +231,11 @@ return array(
     // 'Original link marks article as read' => '',
     // 'Cloak the image referrer' => '',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/es_ES/translations.php
+++ b/locales/es_ES/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'Link original marca artículo cómo leído',
     // 'Cloak the image referrer' => '',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/fr_FR/translations.php
+++ b/locales/fr_FR/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'Marquer les articles comme lu lors d\'un clic sur le lien original',
     'Cloak the image referrer' => 'Falsifier le référent pour les images',
     'This subscription already exists.' => 'Cet abonnement existe déjà.',
+    'Connection timeout.' => 'Connection timeout.',
+    'Error occured.' => 'Error occured.',
+    'Feed is malformed.' => 'Feed is malformed.',
+    'Invalid SSL certificate.' => 'Invalid SSL certificate.',
+    'Maximum number of HTTP redirections exceeded.' => 'Maximum number of HTTP redirections exceeded.',
+    'The content size exceeds to maximum allowed size.' => 'The content size exceeds to maximum allowed size.',
+    'Unable to detect the feed format.' => 'Unable to detect the feed format.',
 );

--- a/locales/it_IT/translations.php
+++ b/locales/it_IT/translations.php
@@ -231,4 +231,11 @@ return array(
     // 'Original link marks article as read' => '',
     // 'Cloak the image referrer' => '',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/pt_BR/translations.php
+++ b/locales/pt_BR/translations.php
@@ -231,4 +231,11 @@ return array(
     // 'Original link marks article as read' => '',
     // 'Cloak the image referrer' => '',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/sr_RS/translations.php
+++ b/locales/sr_RS/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'Клик на оригиналну везу обележава чланак прочитаним',
     'Cloak the image referrer' => 'Прикривај рефератора слика',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/sr_RS@latin/translations.php
+++ b/locales/sr_RS@latin/translations.php
@@ -231,4 +231,11 @@ return array(
     'Original link marks article as read' => 'Klik na originalnu vezu obeležava članak pročitanim',
     'Cloak the image referrer' => 'Prikrivaj referatora slika',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/zh_CN/translations.php
+++ b/locales/zh_CN/translations.php
@@ -231,4 +231,11 @@ return array(
     // 'Original link marks article as read' => '',
     // 'Cloak the image referrer' => '',
     // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );


### PR DESCRIPTION
Great, we both have done the same work :-(.

I've used custom return values on the first run as well. But I felt it wasn't the right way to handle the "subscription already exists" condition. After I slept on it, I switched to an exception for this error as well.

IMHO the user should know the cause why something fails. This way (s)he is able to fix things by them self. As a sideeffect, there is a chance that we get more helpful bug reports. This commit can be seen as a follow up to #303.

Generally, exception handling should be done within the controller. At least to my understanding, the controller is the natural place for handling exceptions.