### PR TITLE
fix Helper\summary bug

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -116,7 +116,11 @@ function summary($value, $min_length = 5, $max_length = 120, $end = '[...]')
     $length = strlen($value);
 
     if ($length > $max_length) {
-        return substr($value, 0, strpos($value, ' ', $max_length)).' '.$end;
+        $max = strpos($value, ' ', $max_length);
+        if ($max === false) {
+            $max = $max_length;
+        }
+        return substr($value, 0, $max).' '.$end;
     }
     else if ($length < $min_length) {
         return '';


### PR DESCRIPTION
`/lib/helpers.php`, line 114, `summary` method .
```php
function summary($value, $min_length = 5, $max_length = 120, $end = '[...]')
{
    $length = strlen($value);

    if ($length > $max_length) {
        return substr($value, 0, strpos($value, ' ', $max_length)).' '.$end;
    }
    else if ($length < $min_length) {
        return '';
    }

    return $value;
}

```

if `strpos($value, ' ', $max_length)` return `FALSE`
then
`substr($value, 0, strpos($value, ' ', $max_length))` == `''`

POC:
```php
<?php

function summary($value, $min_length = 5, $max_length = 120, $end = '[...]')
{
    $length = strlen($value);

    if ($length > $max_length) {
        return substr($value, 0, strpos($value, ' ', $max_length)).' '.$end;
    }
    else if ($length < $min_length) {
        return '';
    }

    return $value;
}

$content = '“近年来随着富士康手机项目落户河南省，以手机为代表的新兴产业已取代传统产业，独占外贸进出口鳌头，并成为河南外贸的支柱产业。”在郑州海关“2015年二季度新闻发布会”上，该关办公室主任黄琳作出上述介绍。据统计，今年一季度，河南省进出口总值1008.4亿元人民币，同比增长22%。富士康所属企业进出口占该省的63.5%，贡献率高达92.3%。';

$result = summary(strip_tags($content), 50, 300);

var_dump($result);//string(6) " [...]"
```


My solution:
```php
function summary($value, $min_length = 5, $max_length = 120, $end = '[...]')
{
    $length = strlen($value);

    if ($length > $max_length) {
        $max = strpos($value, ' ', $max_length);
        if($max === false){
            $max = $max_length;
        }
        return substr($value, 0, $max).' '.$end;
    }
    else if ($length < $min_length) {
        return '';
    }

    return $value;
}
```