### PR TITLE
Moved Favicons to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ config.php
 !models/*
 !controllers/*
 rules/*.php
+data/favicons/*.ico

--- a/check_setup.php
+++ b/check_setup.php
@@ -62,6 +62,11 @@ if (! is_writable(DATA_DIRECTORY)) {
     die('The data directory must be writeable by your web server user');
 }
 
+// Check if /data is writeable
+if (! is_writable(FAVICON_DIRECTORY)) {
+    die('The favicon inside the data directory must be writeable by your web server user');
+}
+
 // Include password_compat for PHP < 5.5
 if (version_compare(PHP_VERSION, '5.5.0', '<')) {
     require __DIR__.'/lib/password.php';

--- a/common.php
+++ b/common.php
@@ -13,6 +13,11 @@ defined('BASE_URL_DIRECTORY') or define('BASE_URL_DIRECTORY', dirname($_SERVER['
 defined('ROOT_DIRECTORY') or define('ROOT_DIRECTORY', __DIR__);
 defined('DATA_DIRECTORY') or define('DATA_DIRECTORY', ROOT_DIRECTORY.DIRECTORY_SEPARATOR.'data');
 
+defined('FAVICON_DIRECTORY') or define('FAVICON_DIRECTORY', DATA_DIRECTORY.DIRECTORY_SEPARATOR.'favicons');
+defined('FAVICON_DIRECTORY_PUBLIC') or define('FAVICON_DIRECTORY_PUBLIC', 'data'.DIRECTORY_SEPARATOR.'favicons'.DIRECTORY_SEPARATOR);
+defined('FAVICON_EXT') or define('FAVICON_EXT', '.ico');
+
+
 defined('ENABLE_MULTIPLE_DB') or define('ENABLE_MULTIPLE_DB', true);
 defined('DB_FILENAME') or define('DB_FILENAME', 'db.sqlite');
 

--- a/config.default.php
+++ b/config.default.php
@@ -6,6 +6,12 @@ define('HTTP_TIMEOUT', '20');
 // DATA_DIRECTORY => default is data (writable directory)
 define('DATA_DIRECTORY', __DIR__.'/data');
 
+// FAVICON_DIRECTORY => where your favicons will be saved to (writable directory)
+define('FAVICON_DIRECTORY', DATA_DIRECTORY.'/favicons');
+
+// FAVICON_DIRECTORY_PUBLIC => public path to the favicon directory which is accessable via browser
+define('FAVICON_DIRECTORY_PUBLIC', 'data'.DIRECTORY_SEPARATOR.'favicons'.DIRECTORY_SEPARATOR);
+
 // DB_FILENAME => default value is db.sqlite (default database filename)
 define('DB_FILENAME', 'db.sqlite');
 

--- a/controllers/bookmark.php
+++ b/controllers/bookmark.php
@@ -45,7 +45,6 @@ Router\get_action('bookmarks', function() {
     $items = Model\Item\get_bookmarks($offset, Model\Config\get('items_per_page'));
 
     Response\html(Template\layout('bookmarks', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'order' => '',
         'direction' => '',

--- a/controllers/feed.php
+++ b/controllers/feed.php
@@ -116,7 +116,6 @@ Router\get_action('feeds', function() {
     }
 
     Response\html(Template\layout('feeds', array(
-        'favicons' => Model\Feed\get_all_favicons(),
         'feeds' => Model\Feed\get_all_item_counts(),
         'nothing_to_read' => $nothing_to_read,
         'nb_unread_items' => $nb_unread_items,

--- a/controllers/history.php
+++ b/controllers/history.php
@@ -19,7 +19,6 @@ Router\get_action('history', function() {
     );
 
     Response\html(Template\layout('history', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'items' => $items,
         'order' => '',

--- a/controllers/item.php
+++ b/controllers/item.php
@@ -24,7 +24,6 @@ Router\get_action('unread', function() {
     }
 
     Response\html(Template\layout('unread_items', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'order' => $order,
         'direction' => $direction,
@@ -96,7 +95,6 @@ Router\get_action('feed-items', function() {
     $items = Model\Item\get_all_by_feed($feed_id, $offset, Model\Config\get('items_per_page'), $order, $direction);
 
     Response\html(Template\layout('feed_items', array(
-        'favicons' => Model\Feed\get_favicons(array($feed['id'])),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'order' => $order,
         'direction' => $direction,

--- a/data/favicons/.htaccess
+++ b/data/favicons/.htaccess
@@ -1,0 +1,4 @@
+Allow from all
+
+#Enable caching for a years time
+Header set Cache-Control "max-age=29030400, public"

--- a/fever/index.php
+++ b/fever/index.php
@@ -124,19 +124,12 @@ route('favicons', function() {
 
     if ($response['auth']) {
 
-        $favicons = Database::get('db')
-            ->table('favicons')
-            ->columns(
-                'feed_id',
-                'icon'
-            )
-            ->findAll();
-
+        $favicons = glob(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.'*'.FAVICON_EXT);
         $response['favicons'] = array();
         foreach ($favicons as $favicon) {
             $response['favicons'][] = array(
-                'id' => (int) $favicon['feed_id'],
-                'data' => $favicon['icon']
+                'id' => (int) basename($favicon, FAVICON_EXT),
+                'data' => 'data:image/'.pathinfo($favicon, PATHINFO_EXTENSION).';base64,'.base64_encode(file_get_contents($favicon))
             );
         }
     }

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -29,10 +29,10 @@ function parse_app_version($refnames, $commithash)
     return $version;
 }
 
-function favicon(array $favicons, $feed_id)
+function favicon($feed_id)
 {
-    if (! empty($favicons[$feed_id])) {
-        return '<img src="'.$favicons[$feed_id].'" class="favicon"/>';
+    if (!empty($feed_id)) {
+        return '<img src="'.FAVICON_DIRECTORY_PUBLIC.$feed_id.FAVICON_EXT.'" class="favicon"/>';
     }
 
     return '';

--- a/models/feed.php
+++ b/models/feed.php
@@ -20,13 +20,7 @@ const LIMIT_ALL = -1;
 // Store the favicon
 function store_favicon($feed_id, $link, $icon)
 {
-    return Database::get('db')
-            ->table('favicons')
-            ->save(array(
-                'feed_id' => $feed_id,
-                'link' => $link,
-                'icon' => $icon,
-            ));
+    return file_put_contents(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.$feed_id.FAVICON_EXT, $icon);
 }
 
 // Download favicon
@@ -36,7 +30,7 @@ function fetch_favicon($feed_id, $site_url, $icon_link)
         $favicon = new Favicon;
 
         $link = $favicon->find($site_url, $icon_link);
-        $icon = $favicon->getDataUri();
+        $icon = $favicon->getContent();
 
         if ($icon !== '') {
             store_favicon($feed_id, $link, $icon);
@@ -47,47 +41,7 @@ function fetch_favicon($feed_id, $site_url, $icon_link)
 // Return true if the feed have a favicon
 function has_favicon($feed_id)
 {
-    return Database::get('db')->table('favicons')->eq('feed_id', $feed_id)->count() === 1;
-}
-
-// Get favicons for those feeds
-function get_favicons(array $feed_ids)
-{
-    if (Config\get('favicons') == 0) {
-        return array();
-    }
-
-    $db = Database::get('db')
-            ->hashtable('favicons')
-            ->columnKey('feed_id')
-            ->columnValue('icon');
-
-    // pass $feeds_ids as argument list to hashtable::get(), use ... operator with php 5.6+
-    return call_user_func_array(array($db, 'get'), $feed_ids);
-}
-
-// Get all favicons for a list of items
-function get_item_favicons(array $items)
-{
-    $feed_ids = array();
-
-    foreach ($items as $item) {
-        $feed_ids[$item['feed_id']] = $item['feed_id'];
-    }
-
-    return get_favicons($feed_ids);
-}
-
-// Get all favicons
-function get_all_favicons()
-{
-    if (Config\get('favicons') == 0) {
-        return array();
-    }
-
-    return Database::get('db')
-            ->hashtable('favicons')
-            ->getAll('feed_id', 'icon');
+    return file_exists(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.$feed_id.FAVICON_EXT);
 }
 
 // Update feed information

--- a/models/schema.php
+++ b/models/schema.php
@@ -5,7 +5,12 @@ namespace Schema;
 use PDO;
 use Model\Config;
 
-const VERSION = 40;
+const VERSION = 41;
+
+function version_41($pdo)
+{
+    $pdo->exec('DROP TABLE favicons');
+}
 
 function version_40($pdo)
 {

--- a/templates/bookmarks.php
+++ b/templates/bookmarks.php
@@ -18,7 +18,6 @@
                 'offset' => $offset,
                 'hide' => false,
                 'display_mode' => $display_mode,
-                'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>
         <?php endforeach ?>

--- a/templates/feed_items.php
+++ b/templates/feed_items.php
@@ -34,7 +34,6 @@
                 'offset' => $offset,
                 'hide' => false,
                 'display_mode' => $display_mode,
-                'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>
         <?php endforeach ?>

--- a/templates/feeds.php
+++ b/templates/feeds.php
@@ -31,7 +31,7 @@
                     <span title="<?= t('Subscription disabled') ?>">✖</span>
                 <?php endif ?>
 
-                <?= Helper\favicon($favicons, $feed['id']) ?>
+                <?= Helper\favicon($feed['id']) ?>
 
                 <a href="?action=feed-items&amp;feed_id=<?= $feed['id'] ?>" title="<?= t('Show only this subscription') ?>"><?= Helper\escape($feed['title']) ?></a>
                 &lrm;<span class="items-count"><?= $feed['items_unread'] .'/' . $feed['items_total'] ?></span>

--- a/templates/history.php
+++ b/templates/history.php
@@ -21,7 +21,6 @@
                 'offset' => $offset,
                 'hide' => true,
                 'display_mode' => $display_mode,
-                'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>
         <?php endforeach ?>

--- a/templates/item.php
+++ b/templates/item.php
@@ -9,7 +9,7 @@
     <h2 <?= Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>>
         <span class="bookmark-icon"></span>
         <span class="read-icon"></span>
-        <?= Helper\favicon($favicons, $item['feed_id']) ?>
+        <?= Helper\favicon($item['feed_id']) ?>
         <a
             href="?action=show&amp;menu=<?= $menu ?>&amp;id=<?= $item['id'] ?>"
             class="show"

--- a/templates/unread_items.php
+++ b/templates/unread_items.php
@@ -22,7 +22,6 @@
                 'offset' => $offset,
                 'hide' => true,
                 'display_mode' => $display_mode,
-                'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>
         <?php endforeach ?>


### PR DESCRIPTION
This reduces the size of the served HTML code as it no long holds all the base64 encoded images. This lead to some errors on memory restricted systems where the allowed limit would be exceeded. Currently all icons are saved as .ico, this still needs to be improved.

Call for suggestions and feedback:
* Do we need to respect the extensions or can we universally assume .ico being used?
* Should we move the code from the fever api to the model?
* Glob command ok?
* Suggestions on caching?
* How do we check if the feed has a icon in the helper function? Currently it simply creates the image tag and the http request will fail - probably not the best solution
* => Should we add a column to the db where we add the extension and simultaneously add a 'has a favicon' check possibility?