### PR TITLE
Add feed tagging/categorising feature

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -247,6 +247,38 @@ textarea.form-error {
     display: none;
 }
 
+/* Feed group buttons */
+#grouplist span {
+    float: left;
+    opacity: 0.4;
+    min-width: 4em;
+    margin-right: 6px;
+    overflow: auto;
+    text-align: center;
+}
+
+#grouplist input[type="text"] {
+    width: 150px;
+}
+
+#grouplist input[type="checkbox"] + span, #grouplist input[type="text"] {
+    padding: 4px;
+    margin-top: 6px;
+    margin-bottom: 0px;
+}
+
+#grouplist input[type="checkbox"]:checked + span {
+    opacity: 1;
+}
+
+ul#grouplist {
+    float: left;
+}
+
+ul#grouplist li {
+    margin-left: 0px;
+}
+
 /* alerts */
 .alert, .panel {
     padding: 8px 35px 8px 14px;
@@ -287,7 +319,7 @@ textarea.form-error {
 }
 
 /* buttons */
-.btn {
+.btn, #grouplist span {
     -webkit-appearance: none;
     appearance: none;
     display: inline-block;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
             "models/schema.php",
             "models/auto_update.php",
             "models/database.php",
-            "models/remember_me.php"
+            "models/remember_me.php",
+            "models/group.php"
         ],
         "classmap": [
             "vendor/fguillot/json-rpc/src/",

--- a/controllers/history.php
+++ b/controllers/history.php
@@ -12,6 +12,7 @@ Router\get_action('history', function() {
     $nb_items = Model\Item\count_by_status('read');
     $items = Model\Item\get_all_by_status(
         'read',
+        null,
         $offset,
         Model\Config\get('items_per_page'),
         'updated',

--- a/fever/index.php
+++ b/fever/index.php
@@ -59,23 +59,8 @@ route('groups', function() {
 
     if ($response['auth']) {
 
-        $feed_ids = Database::get('db')
-                        ->table('feeds')
-                        ->findAllByColumn('id');
-
-        $response['groups'] = array(
-            array(
-                'id' => 1,
-                'title' => t('All'),
-            )
-        );
-
-        $response['feeds_groups'] = array(
-            array(
-                'group_id' => 1,
-                'feed_ids' => implode(',', $feed_ids),
-            )
-        );
+        $response['groups'] = array();
+        $response['feeds_groups'] = array();
     }
 
     response($response);
@@ -89,8 +74,9 @@ route('feeds', function() {
     if ($response['auth']) {
 
         $response['feeds'] = array();
+        $response['feeds_groups'] = array();
+
         $feeds = Feed\get_all();
-        $feed_ids = array();
 
         foreach ($feeds as $feed) {
             $response['feeds'][] = array(
@@ -102,16 +88,7 @@ route('feeds', function() {
                 'is_spark' => 0,
                 'last_updated_on_time' => $feed['last_checked'] ?: time(),
             );
-
-            $feed_ids[] = $feed['id'];
         }
-
-        $response['feeds_groups'] = array(
-            array(
-                'group_id' => 1,
-                'feed_ids' => implode(',', $feed_ids),
-            )
-        );
     }
 
     response($response);
@@ -297,7 +274,7 @@ route('write_feeds', function() {
             ->table('items')
             ->eq('feed_id', $_POST['id'])
             ->lte('updated', $_POST['before'])
-            ->update(array('status' => $_POST['as'] === 'read' ? 'read' : 'unread'));
+            ->update(array('status' => 'read'));
     }
 
     response($response);
@@ -313,7 +290,7 @@ route('write_groups', function() {
         Database::get('db')
             ->table('items')
             ->lte('updated', $_POST['before'])
-            ->update(array('status' => $_POST['as'] === 'read' ? 'read' : 'unread'));
+            ->update(array('status' => 'read'));
     }
 
     response($response);

--- a/jsonrpc.php
+++ b/jsonrpc.php
@@ -115,7 +115,7 @@ $server->register('item.bookmark.delete', function ($item_id) {
 // Get all unread items
 $server->register('item.list_unread', function ($offset = null, $limit = null) {
 
-    return Model\Item\get_all_by_status('unread', $offset, $limit);
+    return Model\Item\get_all_by_status('unread', null, $offset, $limit);
 });
 
 // Count all unread items
@@ -127,7 +127,7 @@ $server->register('item.count_unread', function () {
 // Get all read items
 $server->register('item.list_read', function ($offset = null, $limit = null) {
 
-    return Model\Item\get_all_by_status('read', $offset, $limit);
+    return Model\Item\get_all_by_status('read', null, $offset, $limit);
 });
 
 // Count all read items

--- a/locales/ar_AR/translations.php
+++ b/locales/ar_AR/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/cs_CZ/translations.php
+++ b/locales/cs_CZ/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/de_DE/translations.php
+++ b/locales/de_DE/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/es_ES/translations.php
+++ b/locales/es_ES/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/fr_FR/translations.php
+++ b/locales/fr_FR/translations.php
@@ -238,4 +238,6 @@ return array(
     'Maximum number of HTTP redirections exceeded.' => 'Nombre maximal de redirections HTTP dépassé.',
     'The content size exceeds to maximum allowed size.' => 'La taille du contenu dépasse la taille maximale autorisée.',
     'Unable to detect the feed format.' => 'Impossible de détecter le format du flux.',
+    'add a new group' => 'add a new group',
+    'Groups' => 'Groups',
 );

--- a/locales/it_IT/translations.php
+++ b/locales/it_IT/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/pt_BR/translations.php
+++ b/locales/pt_BR/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/ru_RU/translations.php
+++ b/locales/ru_RU/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/ru_RU/translations.php
+++ b/locales/ru_RU/translations.php
@@ -230,4 +230,12 @@ return array(
     'Enable debug mode' => 'Включить отладочный режим',
     'Original link marks article as read' => 'При переходе на оригинал отмечать статью как прочитанную',
     'Cloak the image referrer' => 'Проксировать загрузку изображений',
+    // 'This subscription already exists.' => '',
+    // 'Connection timeout.' => '',
+    // 'Error occured.' => '',
+    // 'Feed is malformed.' => '',
+    // 'Invalid SSL certificate.' => '',
+    // 'Maximum number of HTTP redirections exceeded.' => '',
+    // 'The content size exceeds to maximum allowed size.' => '',
+    // 'Unable to detect the feed format.' => '',
 );

--- a/locales/sr_RS/translations.php
+++ b/locales/sr_RS/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/sr_RS@latin/translations.php
+++ b/locales/sr_RS@latin/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/locales/zh_CN/translations.php
+++ b/locales/zh_CN/translations.php
@@ -238,4 +238,6 @@ return array(
     // 'Maximum number of HTTP redirections exceeded.' => '',
     // 'The content size exceeds to maximum allowed size.' => '',
     // 'Unable to detect the feed format.' => '',
+    // 'add a new group' => '',
+    // 'Groups' => '',
 );

--- a/models/group.php
+++ b/models/group.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Model\Group;
+
+use PicoDb\Database;
+
+/**
+ * Get all groups
+ *
+ * @return array
+ */
+function get_all()
+{
+    return Database::get('db')
+            ->table('groups')
+            ->orderBy('title')
+            ->findAll();
+}
+
+/**
+ * Get assoc array of group ids with assigned feeds ids
+ *
+ * @return array
+ */
+function get_map()
+{
+    $result = Database::get('db')
+            ->table('feeds_groups')
+            ->findAll();
+
+    // TODO: add PDO::FETCH_COLUMN|PDO::FETCH_GROUP to picodb and use it instead
+    // of the following lines
+    $map = array();
+
+    foreach ($result as $row) {
+        $group_id = $row['group_id'];
+        $feed_id = $row['feed_id'];
+
+        if (isset($map[$group_id])) {
+            $map[$group_id][] = $feed_id;
+        }
+        else {
+            $map[$group_id] = array($feed_id);
+        }
+    }
+
+    return $map;
+}
+
+/**
+ * Get all groups assigned to feed
+ *
+ * @param integer $feed_id id of the feed
+ * @return array
+ */
+function get_feed_group_ids($feed_id)
+{
+    return Database::get('db')
+            ->table('groups')
+            ->join('feeds_groups', 'group_id', 'id')
+            ->eq('feed_id', $feed_id)
+            ->findAllByColumn('id');
+}
+
+/**
+ * Get the id of a group
+ *
+ * @param string $title group name
+ * @return mixed group id or false if not found
+ */
+function get_group_id($title)
+{
+    return Database::get('db')
+            ->table('groups')
+            ->eq('title', $title)
+            ->findOneColumn('id');
+}
+
+/**
+ * Get all feed ids assigned to a group
+ *
+ * @param array $group_id
+ * @return array
+ */
+function get_feeds_by_group($group_id)
+{
+    return Database::get('db')
+            ->table('feeds_groups')
+            ->eq('group_id', $group_id)
+            ->findAllByColumn('feed_id');
+}
+
+/**
+ * Add a group to the Database
+ *
+ * Returns either the id of the new group or the id of an existing group with
+ * the same name
+ *
+ * @param string $title group name
+ * @return mixed id of the created group or false on error
+ */
+function create($title)
+{
+    $data = array('title' => $title);
+
+    // check if the group already exists
+    $group_id = get_group_id($title);
+
+    // create group if missing
+    if ($group_id === false) {
+       Database::get('db')
+                ->table('groups')
+                ->insert($data);
+
+        $group_id = get_group_id($title);
+    }
+
+    return $group_id;
+}
+
+/**
+ * Add groups to feed
+ *
+ * @param integer $feed_id feed id
+ * @param array $group_ids array of group ids
+ * @return boolean true on success, false on error
+ */
+function add($feed_id, $group_ids)
+{
+    foreach ($group_ids as $group_id){
+        $data = array('feed_id' => $feed_id, 'group_id' => $group_id);
+
+        $result = Database::get('db')
+                ->table('feeds_groups')
+                ->insert($data);
+
+        if ($result === false) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Remove groups from feed
+ *
+ * @param integer $feed_id id of the feed
+ * @param array $group_ids array of group ids
+ * @return boolean true on success, false on error
+ */
+function remove($feed_id, $group_ids)
+{
+    return Database::get('db')
+            ->table('feeds_groups')
+            ->eq('feed_id', $feed_id)
+            ->in('group_id', $group_ids)
+            ->remove();
+}
+
+/**
+ * Purge orphaned groups from database
+ */
+function purge_groups()
+{
+    $groups = Database::get('db')
+                ->table('groups')
+                ->join('feeds_groups', 'group_id', 'id')
+                ->isnull('feed_id')
+                ->findAllByColumn('id');
+
+    if (! empty($groups)) {
+        Database::get('db')
+            ->table('groups')
+            ->in('id', $groups)
+            ->remove();
+    }
+}
+
+/**
+ * Update feed group associations
+ *
+ * @param integer $feed_id id of the feed to update
+ * @param array $group_ids valid groups ids for feed
+ * @param string $create_group group to create and assign to feed
+ * @return boolean
+ */
+function update_feed_groups($feed_id, $group_ids, $create_group = '')
+{
+    if ($create_group !== '') {
+        $id = create($create_group);
+
+        if ($id === false) {
+            return false;
+        }
+
+        if (! in_array($id, $group_ids)) {
+            $group_ids[] = $id;
+        }
+    }
+
+    $assigned = get_feed_group_ids($feed_id);
+    $superfluous = array_diff($assigned, $group_ids);
+    $missing = array_diff($group_ids, $assigned);
+
+    // remove no longer assigned groups from feed
+    if (! empty($superfluous) && ! remove($feed_id, $superfluous)) {
+        return false;
+    }
+
+    // add requested groups to feed
+    if (! empty($missing) && ! add($feed_id, $missing)) {
+        return false;
+    }
+
+    // cleanup
+    purge_groups();
+
+    return true;
+}

--- a/models/schema.php
+++ b/models/schema.php
@@ -5,7 +5,27 @@ namespace Schema;
 use PDO;
 use Model\Config;
 
-const VERSION = 40;
+const VERSION = 41;
+
+function version_41($pdo)
+{
+    $pdo->exec('
+        CREATE TABLE "groups" (
+            id INTEGER PRIMARY KEY,
+            title TEXT
+        )
+    ');
+
+    $pdo->exec('
+        CREATE TABLE "feeds_groups" (
+            feed_id INTEGER  NOT NULL,
+            group_id INTEGER NOT NULL,
+            PRIMARY KEY(feed_id, group_id)
+            FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE
+            FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+        )
+    ');
+}
 
 function version_40($pdo)
 {

--- a/templates/add.php
+++ b/templates/add.php
@@ -22,6 +22,16 @@
     <?= Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
 
     <p class="form-help"><?= t('Downloading full content is slower because Miniflux grab the content from the original website. You should use that for subscriptions that display only a summary. This feature doesn\'t work with all websites.') ?></p>
+
+    <?= Helper\form_label(t('Groups'), 'groups'); ?>
+
+    <div id="grouplist">
+        <?php foreach ($groups as $group): ?>
+            <?= Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
+        <?php endforeach ?>
+        <?= Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
+    </div>
+
     <div class="form-actions">
         <button type="submit" class="btn btn-blue"><?= t('Add') ?></button>
         <?= t('or') ?> <a href="?action=feeds"><?= t('cancel') ?></a>

--- a/templates/edit_feed.php
+++ b/templates/edit_feed.php
@@ -27,7 +27,16 @@
 
     <?= Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
 
-    <?= Helper\form_checkbox('enabled', t('Activated'), 1, $values['enabled']) ?>
+    <?= Helper\form_checkbox('enabled', t('Activated'), 1, $values['enabled']) ?><br />
+
+    <?= Helper\form_label(t('Groups'), 'groups'); ?>
+
+    <div id="grouplist">
+        <?php foreach ($groups as $group): ?>
+            <?= Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
+        <?php endforeach ?>
+        <?= Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
+    </div>
 
     <div class="form-actions">
         <button type="submit" class="btn btn-blue"><?= t('Save') ?></button>

--- a/templates/paging.php
+++ b/templates/paging.php
@@ -4,6 +4,6 @@
 <?php endif ?>
 &nbsp;
 <?php if (($nb_items - $offset) > $items_per_page): ?>
-    <a id="next-page" href="?action=<?= $menu ?>&amp;offset=<?= ($offset + $items_per_page) ?>&amp;order=<?= $order ?>&amp;direction=<?= $direction ?><?= isset($feed_id) ? '&amp;feed_id='.$feed_id : '' ?>"><?= t('Next page') ?> »</a>
+    <a id="next-page" href="?action=<?= $menu ?>&amp;offset=<?= ($offset + $items_per_page) ?>&amp;order=<?= $order ?>&amp;direction=<?= $direction ?><?= isset($feed_id) ? '&amp;feed_id='.$feed_id : '' ?><?= isset($group_id) ? '&amp;group_id='.$group_id : '' ?>"><?= t('Next page') ?> »</a>
 <?php endif ?>
 </div>

--- a/templates/unread_items.php
+++ b/templates/unread_items.php
@@ -1,37 +1,49 @@
-<?php if (empty($items)): ?>
-    <p class="alert alert-info"><?= t('Nothing to read') ?></p>
-<?php else: ?>
+
 
     <div class="page-header">
         <h2><?= t('Unread') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <?php if (!empty($groups)): ?>
+        <nav>
+            <ul id="grouplist">
+                <?php foreach ($groups as $group): ?>
+                <li  <?= $group['id'] == $group_id ? 'class="active"' : '' ?>>
+                    <a href="?action=unread&group_id=<?=$group['id']?>"><?=$group['title']?></a>
+                </li>
+                <?php endforeach ?>
+            </ul>
+        </nav>
+        <?php endif ?>
+
         <ul>
             <li>
-                <a href="?action=unread&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
+                <a href="?action=unread<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
             <li>
-                <a href="?action=mark-all-read"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
             </li>
         </ul>
     </div>
 
     <section class="items" id="listing">
-        <?php foreach ($items as $item): ?>
-            <?= \PicoFarad\Template\load('item', array(
-                'item' => $item,
-                'menu' => $menu,
-                'offset' => $offset,
-                'hide' => true,
-                'display_mode' => $display_mode,
-                'favicons' => $favicons,
-                'original_marks_read' => $original_marks_read,
-            )) ?>
-        <?php endforeach ?>
+        <?php if (empty($items)): ?>
+            <p class="alert alert-info"><?= t('Nothing to read') ?></p>
+        <?php else: ?>
+            <?php foreach ($items as $item): ?>
+                <?= \PicoFarad\Template\load('item', array(
+                    'item' => $item,
+                    'menu' => $menu,
+                    'offset' => $offset,
+                    'hide' => true,
+                    'display_mode' => $display_mode,
+                    'favicons' => $favicons,
+                    'original_marks_read' => $original_marks_read,
+                )) ?>
+            <?php endforeach ?>
 
-        <div id="bottom-menu">
-            <a href="?action=mark-all-read"><?= t('mark all as read') ?></a>
-        </div>
+            <div id="bottom-menu">
+                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
+            </div>
 
-        <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction)) ?>
+            <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
+        <?php endif ?>
     </section>
-
-<?php endif ?>

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -18,4 +18,5 @@ return array(
     $baseDir . '/models/auto_update.php',
     $baseDir . '/models/database.php',
     $baseDir . '/models/remember_me.php',
+    $baseDir . '/models/group.php',
 );


### PR DESCRIPTION
As long as no tag is added to any feed, the frontend looks like before.

Tags are exported as groups via Fever API. The "virtual group" ALL
isn't exported any longer via Fever API. The group was used as catch-all
because of the absence of groups within miniflux. This is neither forced
by the API nor required with Reeder on iOS. Reeder displays untagged
feeds at the top level, side by side possibly present groups.

Solution for #251