### PR TITLE
Added group feature and link to original author to docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,7 @@
 Contributors
 ============
 
-Original author: Frédéric Guillot
+Original author: [Frédéric Guillot](https://github.com/fguillot)
 
 List of contributors:
 

--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,7 @@ Features
 - Keyboard shortcuts
 - Full article download for feeds that display only a summary
 - Bookmarks
+- Groups for categorization of feeds (like folders or tags)
 - Send your favorite articles to Pinboard and Instapaper
 - Enclosure support (videos and podcasts)
 - Feed updates via a cronjob or with the user interface with one click
@@ -64,7 +65,7 @@ License
 Authors
 -------
 
-- Original author: Frédéric Guillot
+- Original author: [Frédéric Guillot](https://github.com/fguillot)
 - [List of contributors](CONTRIBUTORS.md)
 
 Related projects

--- a/docs/fever.markdown
+++ b/docs/fever.markdown
@@ -4,10 +4,13 @@ Fever API
 Miniflux support the [Fever API](http://feedafever.com/api).
 That means you can use mobile applications compatible with Fever.
 
-This feature have been tested with the following apps:
+This feature has been tested with the following apps:
 
 - [Press for Android](http://twentyfivesquares.com/press/)
-- [Reeder 2](http://reederapp.com/) (iOS and OSX)
+- [Reeder 2](http://reederapp.com/) (iOS and OS X)
+- [Reeder 3](http://reederapp.com/) (OS X)
+- [ReadKit](http://readkitapp.com/) (OS X)
+
 
 Configuration
 -------------
@@ -24,11 +27,10 @@ Multiple databases/users
 
 Multiple databases can be used with the Fever API if you have Apache and the `mod_rewrite` enabled.
 
-The Fever URL becomes `http:///your_miniflux_url/myuser.sqlite/`.
+The Fever URL becomes `http://your_miniflux_url/myuser.sqlite/`.
 
 Notes
 -----
 
-- Links, sparks, kindling and groups are not supported.
-- All feeds will be under a category "All" because Miniflux doesn't support categories.
+- Links, sparks and kindlings are not supported.
 - Only JSON responses are handled.


### PR DESCRIPTION
- Removed mention of unsupported groups feature for Fever API
+ Added groups feature to feature list
+ Linked to Frédéric’s personal GitHub profile
+ Added more clients to tested with Fever API
~ Fixed URL typo

Fixes #408