### PR TITLE
Use case insensitive compare when validating the fever api key

### DIFF
--- a/fever/index.php
+++ b/fever/index.php
@@ -46,7 +46,7 @@ function auth()
 
     $response = array(
         'api_version' => 3,
-        'auth' => (int) (@$_POST['api_key'] === $api_key),
+        'auth' => (int) (isset($_POST['api_key']) && (strcasecmp($_POST['api_key'],  $api_key) === 0 )),
         'last_refreshed_on_time' => time(),
     );
 


### PR DESCRIPTION
User aschilling made some extensive client tests with miniflux and noticed that Mr Reader (iOS) and ReadKit (OSX) are sending the API key in upper case.