### PR TITLE
Use files for favicons

### DIFF
--- a/check_setup.php
+++ b/check_setup.php
@@ -62,6 +62,11 @@ if (! is_writable(DATA_DIRECTORY)) {
     die('The data directory must be writeable by your web server user');
 }
 
+// Check if favicon directory is writeable
+if (! is_writable(FAVICON_DIRECTORY)) {
+    die('The favicon directory must be writeable by your web server user');
+}
+
 // Include password_compat for PHP < 5.5
 if (version_compare(PHP_VERSION, '5.5.0', '<')) {
     require __DIR__.'/lib/password.php';

--- a/common.php
+++ b/common.php
@@ -15,6 +15,9 @@ defined('BASE_URL_DIRECTORY') or define('BASE_URL_DIRECTORY', dirname($_SERVER['
 defined('ROOT_DIRECTORY') or define('ROOT_DIRECTORY', __DIR__);
 defined('DATA_DIRECTORY') or define('DATA_DIRECTORY', ROOT_DIRECTORY.DIRECTORY_SEPARATOR.'data');
 
+defined('FAVICON_DIRECTORY') or define('FAVICON_DIRECTORY', DATA_DIRECTORY.DIRECTORY_SEPARATOR.'favicons');
+defined('FAVICON_PUBLIC_DIRECTORY') or define('FAVICON_PUBLIC_DIRECTORY', 'data'.DIRECTORY_SEPARATOR.'favicons');
+
 defined('ENABLE_MULTIPLE_DB') or define('ENABLE_MULTIPLE_DB', true);
 defined('DB_FILENAME') or define('DB_FILENAME', 'db.sqlite');
 

--- a/config.default.php
+++ b/config.default.php
@@ -9,6 +9,12 @@ define('HTTP_MAX_RESPONSE_SIZE', 2097152);
 // DATA_DIRECTORY => default is data (writable directory)
 define('DATA_DIRECTORY', __DIR__.'/data');
 
+// FAVICON_DIRECTORY => default is favicons (writable directory)
+define('FAVICON_DIRECTORY', DATA_DIRECTORY.DIRECTORY_SEPARATOR.'favicons');
+
+// FAVICON_PUBLIC_DIRECTORY => default is data/favicons/
+define('FAVICON_PUBLIC_DIRECTORY', 'data'.DIRECTORY_SEPARATOR.'favicons');
+
 // DB_FILENAME => default value is db.sqlite (default database filename)
 define('DB_FILENAME', 'db.sqlite');
 

--- a/data/favicons/.htaccess
+++ b/data/favicons/.htaccess
@@ -1,0 +1,1 @@
+Allow from all

--- a/fever/index.php
+++ b/fever/index.php
@@ -122,7 +122,8 @@ route('favicons', function() {
             ->table('favicons')
             ->columns(
                 'feed_id',
-                'icon'
+                'file',
+                'type'
             )
             ->findAll();
 
@@ -130,7 +131,7 @@ route('favicons', function() {
         foreach ($favicons as $favicon) {
             $response['favicons'][] = array(
                 'id' => (int) $favicon['feed_id'],
-                'data' => $favicon['icon']
+                'data' => 'data:'.$favicon['type'].';base64,'.base64_encode(file_get_contents(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.$favicon['file']))
             );
         }
     }

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -29,10 +29,30 @@ function parse_app_version($refnames, $commithash)
     return $version;
 }
 
+/*
+ * get Image extension from mime type
+ */
+function favicon_extension($type)
+{
+    $types = array(
+        'image/png' => '.png',
+        'image/gif' => '.gif',
+        'image/x-icon' => '.ico',
+        'image/jpeg' => '.jpg',
+        'image/jpg' => '.jpg'
+    );
+
+    if (in_array($type, $types)) {
+        return $types[$type];
+    } else {
+        return '.ico';
+    }
+}
+
 function favicon(array $favicons, $feed_id)
 {
     if (! empty($favicons[$feed_id])) {
-        return '<img src="'.$favicons[$feed_id].'" class="favicon"/>';
+        return '<img src="'.FAVICON_PUBLIC_DIRECTORY.DIRECTORY_SEPARATOR.$favicons[$feed_id].'" class="favicon"/>';
     }
 
     return '';

--- a/models/schema.php
+++ b/models/schema.php
@@ -5,7 +5,22 @@ namespace Schema;
 use PDO;
 use Model\Config;
 
-const VERSION = 41;
+const VERSION = 42;
+
+function version_42(PDO $pdo)
+{
+    $pdo->exec('DROP TABLE favicons');
+
+    $pdo->exec(
+        'CREATE TABLE favicons (
+            feed_id INTEGER UNIQUE,
+            link TEXT,
+            file TEXT,
+            type TEXT,
+            FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+        )'
+    );
+}
 
 function version_41(PDO $pdo)
 {


### PR DESCRIPTION
Based on #390, but still using the `favicons` table.

Unsure about:
* Where to write the favicons. For now they are in `data/favicons` but it requires adding an `Allow` directive into the httpd configuration.
* Image type/extension storage. Do you think the app should store the favicon file name and read the type when needed (for the fever api), or store the type and build the file name from it? (Currently there are both a type and file column in the favicons table.)