### PR TITLE
fix a display glitch in full content mode

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -578,7 +578,7 @@ nav .active a {
     color: #666;
 }
 
-.preview-full-content p, p.preview:not(:empty) {
+.preview-full-content:not(:empty), p.preview:not(:empty) {
     margin-top: 15px;
 }
 

--- a/templates/item.php
+++ b/templates/item.php
@@ -69,9 +69,7 @@
         <?= \Template\load('status_links', array('item' => $item, 'redirect' => $menu, 'offset' => $offset)) ?>
     </ul>
     <?php if ($display_mode === 'full'): ?>
-        <div class="preview-full-content" <?= Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>>
-            <?= $item['content'] ?>
-        </div>
+        <div class="preview-full-content" <?= Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?= $item['content'] ?></div>
     <?php else: ?>
         <p class="preview" <?= Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?= Helper\escape(Helper\summary(strip_tags($item['content']), 50, 300)) ?></p>
     <?php endif ?>


### PR DESCRIPTION
Articles without paragraphs should have a margin to item action as well. Fix this issue by adding the margin to the container element.

There must be no space between between the <div class="preview-full-content"> and the $item['content']. The CSS pseudo-class :empty does not consider a div with whitespaces only as empty.  The Selectors Level 4 Draft[1] as of 13 September 2015, mentions the CSS pseudo-class :blank which will do so. But it's a draft and not yet implemented by the majority of the browsers.

[1] https://drafts.csswg.org/selectors-4/#the-blank-pseudo