### PR TITLE
Limit the heading to one line for desktop clients

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -857,6 +857,12 @@ html[dir="rtl"] span.items-count:before {
     .hide-desktop {
         display: none;
     }
+
+    .items h2 {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    }
 }
 
 /* mobile design */

--- a/templates/item.php
+++ b/templates/item.php
@@ -14,11 +14,13 @@
             <a class="original" rel="noreferrer" target="_blank"
                href="<?= $item['url'] ?>"
                <?= ($original_marks_read) ? 'data-action="mark-read"' : '' ?>
+               title="<?= Helper\escape($item['title']) ?>"
             ><?= Helper\escape($item['title']) ?></a>
         <?php else: ?>
             <a
                 href="?action=show&amp;menu=<?= $menu ?><?= isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item['id'] ?>"
                 class="show"
+                title="<?= Helper\escape($item['title']) ?>"
             ><?= Helper\escape($item['title']) ?></a>
         <?php endif ?>
     </h2>


### PR DESCRIPTION
Provide the full title using the title attribute (will be shown by on mouse over for desktop browsers).

That's how it looked like before:

![before](https://cloud.githubusercontent.com/assets/4547948/11761447/a3cd4986-a0c3-11e5-8ba1-9ba6cdd7c7b7.png)

That's how it looks like now:

![after](https://cloud.githubusercontent.com/assets/4547948/11761448/a79e59b0-a0c3-11e5-9573-d91fce3e0a53.png)

It's limited to desktop clients, since I'm unsure whether it would strip top much information for mobile clients. @kordianbruck any opinion about this?

It has been tested with chrome, firefox, edge and ie 11.