### PR TITLE
remove error flag from feed on edit

### DIFF
--- a/models/feed.php
+++ b/models/feed.php
@@ -132,6 +132,7 @@ function update(array $values)
                 'rtl' => $values['rtl'],
                 'download_content' => $values['download_content'],
                 'cloak_referrer' => $values['cloak_referrer'],
+                'parsing_error' => 0,
             ));
 
     if ($result) {


### PR DESCRIPTION
If someone edits a faulty feed, it's very likely with the intention to either fix or disable the feed. The information that the feed has issues might not any longer true.

Fixes #456