### PR TITLE
Enable Cache-Control in fav icons

### DIFF
--- a/data/favicons/.htaccess
+++ b/data/favicons/.htaccess
@@ -1,1 +1,6 @@
 Allow from all
+
+#Enable caching for a year
+<ifModule mod_headers.c>
+	Header set Cache-Control "max-age=29030400, public"
+</ifModule>


### PR DESCRIPTION
This should enable cache control for the favicons in addition to Etags 