### PR TITLE
Use hashes to identify favicons

### DIFF
--- a/controllers/bookmark.php
+++ b/controllers/bookmark.php
@@ -41,7 +41,7 @@ Router\get_action('bookmarks', function() {
     $items = Model\Item\get_bookmarks($offset, Model\Config\get('items_per_page'));
 
     Response\html(Template\layout('bookmarks', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
+        'favicons' => Model\Favicon\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'order' => '',
         'direction' => '',

--- a/controllers/feed.php
+++ b/controllers/feed.php
@@ -124,7 +124,7 @@ Router\get_action('feeds', function() {
     }
 
     Response\html(Template\layout('feeds', array(
-        'favicons' => Model\Feed\get_all_favicons(),
+        'favicons' => Model\Favicon\get_all_favicons(),
         'feeds' => Model\Feed\get_all_item_counts(),
         'nothing_to_read' => $nothing_to_read,
         'nb_unread_items' => $nb_unread_items,

--- a/controllers/history.php
+++ b/controllers/history.php
@@ -15,7 +15,7 @@ Router\get_action('history', function() {
     );
 
     Response\html(Template\layout('history', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
+        'favicons' => Model\Favicon\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'items' => $items,
         'order' => '',

--- a/controllers/item.php
+++ b/controllers/item.php
@@ -34,7 +34,7 @@ Router\get_action('unread', function() {
     }
 
     Response\html(Template\layout('unread_items', array(
-        'favicons' => Model\Feed\get_item_favicons($items),
+        'favicons' => Model\Favicon\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
         'order' => $order,
         'direction' => $direction,

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -42,7 +42,7 @@ function favicon_extension($type)
         'image/jpg' => '.jpg'
     );
 
-    if (in_array($type, $types)) {
+    if (array_key_exists($type, $types)) {
         return $types[$type];
     } else {
         return '.ico';
@@ -52,7 +52,7 @@ function favicon_extension($type)
 function favicon(array $favicons, $feed_id)
 {
     if (! empty($favicons[$feed_id])) {
-        return '<img src="'.FAVICON_URL_PATH.'/'.$favicons[$feed_id].'" class="favicon"/>';
+        return '<img src="'.FAVICON_URL_PATH.'/'.$favicons[$feed_id]['hash'].favicon_extension($favicons[$feed_id]['type']).'" class="favicon"/>';
     }
 
     return '';

--- a/models/favicon.php
+++ b/models/favicon.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Model\Favicon;
+
+use UnexpectedValueException;
+use Model\Config;
+use Model\Item;
+use Model\Group;
+use Helper;
+use SimpleValidator\Validator;
+use SimpleValidator\Validators;
+use PicoDb\Database;
+use PicoFeed\Serialization\Export;
+use PicoFeed\Serialization\Import;
+use PicoFeed\Reader\Reader;
+use PicoFeed\Reader\Favicon;
+use PicoFeed\PicoFeedException;
+use PicoFeed\Client\InvalidUrlException;
+
+const LIMIT_ALL = -1;
+
+// Create a favicons
+function create_feed_favicon($feed_id, $site_url, $icon_link) {
+    if (has_favicon($feed_id)) {
+        return true;
+    }
+
+    $favicon = fetch($feed_id, $site_url, $icon_link);
+
+    if ($favicon === false) {
+        return false;
+    }
+
+    $favicon_id = store($favicon->getType(), $favicon->getContent());
+
+    if ($favicon_id === false) {
+        return false;
+    }
+
+    return Database::getInstance('db')
+            ->table('favicons_feeds')
+            ->save(array(
+                'feed_id' => $feed_id,
+                'favicon_id' => $favicon_id
+            ));
+}
+
+// Download a favicon
+function fetch($feed_id, $site_url, $icon_link)
+{
+    if (Config\get('favicons') == 1 && ! has_favicon($feed_id)) {
+        $favicon = new Favicon;
+        $favicon->find($site_url, $icon_link);
+        return $favicon;
+    }
+
+    return false;
+}
+
+// Store the favicon (only if it does not exist yet)
+function store($type, $icon)
+{
+    if ($icon == "") {
+        return false;
+    }
+
+    $hash = sha1($icon);
+
+    $favicon_id = get_favicon_id($hash);
+
+    if ($favicon_id) {
+        return $favicon_id;
+    }
+
+    $file = $hash.Helper\favicon_extension($type);
+
+    if (file_put_contents(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.$file, $icon) === false) {
+        return false;
+    }
+
+    $saved = Database::getInstance('db')
+            ->table('favicons')
+            ->save(array(
+                'hash' => $hash,
+                'type' => $type
+            ));
+
+    if ($saved === false) {
+        return false;
+    }
+
+    return get_favicon_id($hash);
+}
+
+function get_favicon_id($hash) {
+    return Database::getInstance('db')
+          ->table('favicons')
+          ->eq('hash', $hash)
+          ->findOneColumn('id');
+}
+
+// Delete the favicon
+function delete_favicon($favicon)
+{
+    unlink(FAVICON_DIRECTORY.DIRECTORY_SEPARATOR.$favicon['hash'].Helper\favicon_extension($favicon['type']));
+    Database::getInstance('db')
+        ->table('favicons')
+        ->eq('hash', $favicon['hash'])
+        ->remove();
+}
+
+// Purge orphaned favicons from database
+function purge_favicons()
+{
+    $favicons = Database::getInstance('db')
+                ->table('favicons')
+                ->columns(
+                    'favicons.type',
+                    'favicons.hash',
+                    'favicons_feeds.feed_id'
+                )
+                ->join('favicons_feeds', 'favicon_id', 'id')
+                ->isnull('favicons_feeds.feed_id')
+                ->findAll();
+
+      foreach ($favicons as $favicon) {
+         delete_favicon($favicon);
+      }
+}
+
+// Return true if the feed has a favicon
+function has_favicon($feed_id)
+{
+    return Database::getInstance('db')->table('favicons_feeds')->eq('feed_id', $feed_id)->count() === 1;
+}
+
+// Get favicons for those feeds
+function get_favicons(array $feed_ids)
+{
+    if (Config\get('favicons') == 0) {
+        return array();
+    }
+
+    $result = array();
+
+    foreach ($feed_ids as $feed_id) {
+        $result[$feed_id] = Database::getInstance('db')
+              ->table('favicons')
+              ->columns(
+                  'favicons.type',
+                  'favicons.hash'
+              )
+              ->join('favicons_feeds', 'favicon_id', 'id')
+              ->eq('favicons_feeds.feed_id', $feed_id)
+              ->findOne();
+    }
+
+    return $result;
+}
+
+// Get all favicons for a list of items
+function get_item_favicons(array $items)
+{
+    $feed_ids = array();
+
+    foreach ($items as $item) {
+        $feed_ids[$item['feed_id']] = $item['feed_id'];
+    }
+
+    return get_favicons($feed_ids);
+}
+
+// Get all favicons
+function get_all_favicons()
+{
+    if (Config\get('favicons') == 0) {
+        return array();
+    }
+
+    $result = Database::getInstance('db')
+            ->table('favicons')
+            ->columns(
+                'favicons_feeds.feed_id',
+                'favicons.type',
+                'favicons.hash'
+            )
+            ->join('favicons_feeds', 'favicon_id', 'id')
+            ->findAll();
+    
+    $map = array();
+
+    foreach ($result as $row) {
+      $map[$row['feed_id']] = array (
+        "type" => $row['type'],
+        "hash" => $row['hash']
+      );
+    }
+
+    return $map;
+}
+
+

--- a/models/schema.php
+++ b/models/schema.php
@@ -5,7 +5,30 @@ namespace Schema;
 use PDO;
 use Model\Config;
 
-const VERSION = 42;
+const VERSION = 43;
+
+function version_43(PDO $pdo)
+{
+    $pdo->exec('DROP TABLE favicons');
+
+    $pdo->exec(
+        'CREATE TABLE favicons (
+            id INTEGER PRIMARY KEY,
+            hash TEXT UNIQUE,
+            type TEXT
+        )'
+    );
+
+    $pdo->exec('
+        CREATE TABLE "favicons_feeds" (
+            feed_id INTEGER NOT NULL,
+            favicon_id INTEGER NOT NULL,
+            PRIMARY KEY(feed_id, favicon_id)
+            FOREIGN KEY(favicon_id) REFERENCES favicons(id) ON DELETE CASCADE
+            FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+        )
+    ');
+}
 
 function version_42(PDO $pdo)
 {

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -24,4 +24,5 @@ return array(
     $baseDir . '/models/database.php',
     $baseDir . '/models/remember_me.php',
     $baseDir . '/models/group.php',
+    $baseDir . '/models/favicon.php',
 );


### PR DESCRIPTION
As suggested in https://github.com/miniflux/miniflux/pull/440#issuecomment-162806506, use sha1 to identify favicons. Allows to:
* Share the favicon folder between users (a parameter to disable purge could be useful in this case)
* Never store duplicate favicons