### PR TITLE
Possibility of changing item title link in summarize display mode

### DIFF
--- a/controllers/bookmark.php
+++ b/controllers/bookmark.php
@@ -46,6 +46,7 @@ Router\get_action('bookmarks', function() {
         'order' => '',
         'direction' => '',
         'display_mode' => Model\Config\get('items_display_mode'),
+        'item_title_link' => Model\Config\get('item_title_link'),
         'items' => $items,
         'nb_items' => $nb_items,
         'offset' => $offset,

--- a/controllers/config.php
+++ b/controllers/config.php
@@ -123,6 +123,7 @@ Router\get_action('config', function() {
         'theme_options' => Model\Config\get_themes(),
         'sorting_options' => Model\Config\get_sorting_directions(),
         'display_mode' => Model\Config\get_display_mode(),
+        'item_title_link' => Model\Config\get_item_title_link(),
         'redirect_nothing_to_read_options' => Model\Config\get_nothing_to_read_redirections(),
         'nb_unread_items' => Model\Item\count_by_status('unread'),
         'menu' => 'config',
@@ -161,6 +162,7 @@ Router\post_action('config', function() {
         'sorting_options' => Model\Config\get_sorting_directions(),
         'redirect_nothing_to_read_options' => Model\Config\get_nothing_to_read_redirections(),
         'display_mode' => Model\Config\get_display_mode(),
+        'item_title_link' => Model\Config\get_item_title_link(),
         'nb_unread_items' => Model\Item\count_by_status('unread'),
         'menu' => 'config',
         'title' => t('Preferences')

--- a/controllers/history.php
+++ b/controllers/history.php
@@ -21,6 +21,7 @@ Router\get_action('history', function() {
         'order' => '',
         'direction' => '',
         'display_mode' => Model\Config\get('items_display_mode'),
+        'item_title_link' => Model\Config\get('item_title_link'),
         'nb_items' => $nb_items,
         'nb_unread_items' => Model\Item\count_by_status('unread'),
         'offset' => $offset,

--- a/controllers/item.php
+++ b/controllers/item.php
@@ -39,6 +39,7 @@ Router\get_action('unread', function() {
         'order' => $order,
         'direction' => $direction,
         'display_mode' => Model\Config\get('items_display_mode'),
+        'item_title_link' => Model\Config\get('item_title_link'),
         'group_id' => $group_id,
         'items' => $items,
         'nb_items' => $nb_items,

--- a/locales/fr_FR/translations.php
+++ b/locales/fr_FR/translations.php
@@ -242,4 +242,6 @@ return array(
     'Groups' => 'Libellés',
     'Back to the group' => 'Revenir sur le groupe',
     'view' => 'voir',
+    // 'Item title links to' => '',
+    // 'Original' => ''
 );

--- a/locales/ru_RU/translations.php
+++ b/locales/ru_RU/translations.php
@@ -242,4 +242,6 @@ return array(
     'Groups' => 'Группы',
     'Back to the group' => 'Назад в группу',
     'view' => 'смотреть',
+    'Item title links to' => 'Заголовок статьи ведет на',
+    'Original' => 'Оригинал'
 );

--- a/models/config.php
+++ b/models/config.php
@@ -149,6 +149,15 @@ function get_display_mode()
 	);
 }
 
+// Item title links to original or full contents
+function get_item_title_link()
+{
+	return array(
+		'original' => t('Original'),
+		'full' => t('Full contents')
+	);
+}
+
 // Autoflush choices for read items
 function get_autoflush_read_options()
 {

--- a/templates/bookmarks.php
+++ b/templates/bookmarks.php
@@ -18,6 +18,7 @@
                 'offset' => $offset,
                 'hide' => false,
                 'display_mode' => $display_mode,
+                'item_title_link' => $item_title_link,
                 'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>

--- a/templates/config.php
+++ b/templates/config.php
@@ -66,6 +66,9 @@
         <?= Helper\form_label(t('Display items on lists'), 'items_display_mode') ?>
         <?= Helper\form_select('items_display_mode', $display_mode, $values, $errors) ?><br/>
 
+        <?= Helper\form_label(t('Item title links to'), 'item_title_link') ?>
+        <?= Helper\form_select('item_title_link', $item_title_link, $values, $errors) ?><br/>
+
         <?= Helper\form_label(t('When there is nothing to read, redirect me to this page'), 'redirect_nothing_to_read') ?>
         <?= Helper\form_select('redirect_nothing_to_read', $redirect_nothing_to_read_options, $values, $errors) ?><br/>
 

--- a/templates/history.php
+++ b/templates/history.php
@@ -21,6 +21,7 @@
                 'offset' => $offset,
                 'hide' => true,
                 'display_mode' => $display_mode,
+                'item_title_link' => $item_title_link,
                 'favicons' => $favicons,
                 'original_marks_read' => $original_marks_read,
             )) ?>

--- a/templates/item.php
+++ b/templates/item.php
@@ -10,7 +10,7 @@
         <span class="bookmark-icon"></span>
         <span class="read-icon"></span>
         <?= Helper\favicon($favicons, $item['feed_id']) ?>
-        <?php if ($display_mode === 'full'): ?>
+        <?php if ($display_mode === 'full' || $item_title_link == 'original'): ?>
             <a class="original" rel="noreferrer" target="_blank"
                href="<?= $item['url'] ?>"
                <?= ($original_marks_read) ? 'data-action="mark-read"' : '' ?>
@@ -42,7 +42,7 @@
         <li class="hide-mobile">
             <span title="<?= dt('%e %B %Y %k:%M', $item['updated']) ?>"><?= Helper\relative_time($item['updated']) ?></span>
         </li>
-        <?php if ($display_mode === 'full'): ?>
+        <?php if ($display_mode === 'full' || $item_title_link == 'original'): ?>
             <li>
                 <a
                     href="?action=show&amp;menu=<?= $menu ?><?= isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item['id'] ?>"

--- a/templates/unread_items.php
+++ b/templates/unread_items.php
@@ -35,6 +35,7 @@
                     'offset' => $offset,
                     'hide' => true,
                     'display_mode' => $display_mode,
+                    'item_title_link' => $item_title_link,
                     'favicons' => $favicons,
                     'original_marks_read' => $original_marks_read,
                     'group_id' => $group_id,


### PR DESCRIPTION
I prefer the Summarize display mode, but I'd like to item title links to original instead of Full contents. So I add option "Item title links to" to preference to get possibility to configure item tittle link.