### PR TITLE
Add edit link in the feed header

### DIFF
--- a/templates/feed_items.php
+++ b/templates/feed_items.php
@@ -11,6 +11,9 @@
                 <a href="?action=refresh-feed&amp;feed_id=<?= $feed['id'] ?>&amp;redirect=feed-items"><?= t('refresh') ?></a>
             </li>
             <li>
+                <a href="?action=edit-feed&amp;feed_id=<?= $feed['id'] ?>"><?= t('edit') ?></a>
+            </li>
+            <li>
                 <a href="?action=feed-items&amp;feed_id=<?= $feed['id'] ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">', $direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
             <li>


### PR DESCRIPTION
This adds an "edit" link in header of the feed page. I needed this when I first installed miniflux to edit all the feeds I imported from tt-rss, perhaps it will be useful for other people as well.