### PR TITLE
Make the whole menu row clickable on small screens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -810,6 +810,7 @@ iframe {
 .menu-more a {
     text-decoration: none;
     color: #333;
+    display: block;
 }
 
 #help-layer {


### PR DESCRIPTION
Not sure if this doesn't break some themes, but it makes the menu more usable with default one.