### PR TITLE
Blocking access to /data with the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,16 @@ FROM ubuntu:14.04
 
 RUN apt-get update && \
     apt-get install -y apache2 php5 php5-sqlite php5-curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    echo "ServerName localhost" >> /etc/apache2/apache2.conf
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN echo \
+    "ServerName localhost\n" \
+    "<Directory /var/www/html/data/>\n" \
+    "    Deny from all\n" \
+    "</Directory>\n" \
+    "<Directory /var/www/html/data/favicons/>\n" \
+    "    Allow from all\n" \
+    "</Directory>\n" >> /etc/apache2/apache2.conf
 
 COPY . /var/www/html
 


### PR DESCRIPTION
Hello,

First of all, thanks for making Miniflux available. It is easy to use, it is fast and it just works well :smiley: 

This PR restricts access to the `/data` folder when running the Docker image.

I hope this helps. Let me know if you need anything :+1: 

Conrad

