### PR TITLE
Improve PHP 5.3.3 compatiblity

### DIFF
--- a/app/check_setup.php
+++ b/app/check_setup.php
@@ -8,11 +8,6 @@ if (version_compare(PHP_VERSION, '5.3.3', '<')) {
 // Checks for PHP < 5.4
 if (version_compare(PHP_VERSION, '5.4.0', '<')) {
 
-    // Short tags must be enabled for PHP < 5.4
-    if (! ini_get('short_open_tag')) {
-        die('This software require to have short tags enabled if you have PHP < 5.4 ("short_open_tag = On")');
-    }
-
     // Magic quotes are deprecated since PHP 5.4
     if (get_magic_quotes_gpc()) {
         die('This software require to have "Magic quotes" disabled, it\'s deprecated since PHP 5.4 ("magic_quotes_gpc = Off")');

--- a/app/models/config.php
+++ b/app/models/config.php
@@ -142,6 +142,7 @@ function get_sorting_directions()
 function get_display_mode()
 {
     return array(
+        'titles' => t('Titles'),
         'summaries' => t('Summaries'),
         'full' => t('Full contents')
     );

--- a/app/models/database.php
+++ b/app/models/database.php
@@ -74,8 +74,9 @@ function get_all()
     $dir = new DirectoryIterator(DATA_DIRECTORY);
 
     foreach ($dir as $fileinfo) {
-        if ($fileinfo->getExtension() === 'sqlite') {
-            $listing[] = $fileinfo->getFilename();
+	$filename = $fileinfo->getFilename();
+        if (preg_match('/sqlite$/', $filename)) {
+            $listing[] = $filename;
         }
     }
 

--- a/app/templates/about.php
+++ b/app/templates/about.php
@@ -1,39 +1,39 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li class="active"><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li class="active"><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 <section>
     <div class="panel panel-default">
-        <h3><?= t('Bookmarks') ?></h3>
+        <h3><?php echo t('Bookmarks') ?></h3>
         <ul>
             <li>
-                <a href="<?= Miniflux\Helper\get_current_base_url(), '?action=bookmark-feed&amp;database=', urlencode($db_name), '&amp;token=', urlencode($config['feed_token']) ?>" target="_blank"><?= t('Bookmark RSS Feed') ?></a>
+                <a href="<?php echo Miniflux\Helper\get_current_base_url(), '?action=bookmark-feed&amp;database=', urlencode($db_name), '&amp;token=', urlencode($config['feed_token']) ?>" target="_blank"><?php echo t('Bookmark RSS Feed') ?></a>
             </li>
         </ul>
     </div>
     <div class="panel panel-default">
-        <h3><?= t('Bookmarklet') ?></h3>
-        <a class="bookmarklet" href="javascript:location.href='<?= Miniflux\Helper\get_current_base_url() ?>?action=subscribe&amp;token=<?= urlencode($config['bookmarklet_token']) ?>&amp;url='+encodeURIComponent(location.href)"><?= t('Subscribe with Miniflux') ?></a> (<?= t('Drag and drop this link to your bookmarks') ?>)
-        <input type="text" class="auto-select" readonly="readonly" value="javascript:location.href='<?= Miniflux\Helper\get_current_base_url() ?>?action=subscribe&amp;token=<?= urlencode($config['bookmarklet_token']) ?>&amp;url='+encodeURIComponent(location.href)"/>
+        <h3><?php echo t('Bookmarklet') ?></h3>
+        <a class="bookmarklet" href="javascript:location.href='<?php echo Miniflux\Helper\get_current_base_url() ?>?action=subscribe&amp;token=<?php echo urlencode($config['bookmarklet_token']) ?>&amp;url='+encodeURIComponent(location.href)"><?php echo t('Subscribe with Miniflux') ?></a> (<?php echo t('Drag and drop this link to your bookmarks') ?>)
+        <input type="text" class="auto-select" readonly="readonly" value="javascript:location.href='<?php echo Miniflux\Helper\get_current_base_url() ?>?action=subscribe&amp;token=<?php echo urlencode($config['bookmarklet_token']) ?>&amp;url='+encodeURIComponent(location.href)"/>
     </div>
     <div class="panel panel-default">
-        <h3><?= t('About') ?></h3>
+        <h3><?php echo t('About') ?></h3>
         <ul>
             <?php if (! empty($config['last_login'])): ?>
-                <li><?= t('Last login:') ?> <strong><?= date('Y-m-d H:i', $config['last_login']) ?></strong></li>
+                <li><?php echo t('Last login:') ?> <strong><?php echo date('Y-m-d H:i', $config['last_login']) ?></strong></li>
             <?php endif ?>
-            <li><?= t('Miniflux version:') ?> <strong><?= APP_VERSION ?></strong></li>
-            <li><?= t('Official website:') ?> <a href="https://miniflux.net" rel="noreferrer" target="_blank">https://miniflux.net</a></li>
-            <li><a href="?action=console"><?= t('Console') ?></a></li>
+            <li><?php echo t('Miniflux version:') ?> <strong><?php echo APP_VERSION ?></strong></li>
+            <li><?php echo t('Official website:') ?> <a href="https://miniflux.net" rel="noreferrer" target="_blank">https://miniflux.net</a></li>
+            <li><a href="?action=console"><?php echo t('Console') ?></a></li>
         </ul>
     </div>
 </section>

--- a/app/templates/add.php
+++ b/app/templates/add.php
@@ -1,39 +1,39 @@
 <div class="page-header">
-    <h2><?= t('New subscription') ?></h2>
+    <h2><?php echo t('New subscription') ?></h2>
     <nav>
         <ul>
-            <li class="active"><a href="?action=add"><?= t('add') ?></a></li>
-            <li><a href="?action=feeds"><?= t('feeds') ?></a></li>
-            <li><a href="?action=import"><?= t('import') ?></a></li>
-            <li><a href="?action=export"><?= t('export') ?></a></li>
+            <li class="active"><a href="?action=add"><?php echo t('add') ?></a></li>
+            <li><a href="?action=feeds"><?php echo t('feeds') ?></a></li>
+            <li><a href="?action=import"><?php echo t('import') ?></a></li>
+            <li><a href="?action=export"><?php echo t('export') ?></a></li>
         </ul>
     </nav>
 </div>
 
 <form method="post" action="?action=subscribe" autocomplete="off">
 
-    <?= Miniflux\Helper\form_hidden('csrf', $values) ?>
+    <?php echo Miniflux\Helper\form_hidden('csrf', $values) ?>
 
-    <?= Miniflux\Helper\form_label(t('Website or Feed URL'), 'url') ?>
-    <?= Miniflux\Helper\form_text('url', $values, array(), array('required', 'autofocus', 'placeholder="'.t('http://website/').'"')) ?><br/><br/>
+    <?php echo Miniflux\Helper\form_label(t('Website or Feed URL'), 'url') ?>
+    <?php echo Miniflux\Helper\form_text('url', $values, array(), array('required', 'autofocus', 'placeholder="'.t('http://website/').'"')) ?><br/><br/>
 
-    <?= Miniflux\Helper\form_checkbox('rtl', t('Force RTL mode (Right-to-left language)'), 1, $values['rtl']) ?><br/>
-    <?= Miniflux\Helper\form_checkbox('download_content', t('Download full content'), 1, $values['download_content']) ?><br/>
-    <?= Miniflux\Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
+    <?php echo Miniflux\Helper\form_checkbox('rtl', t('Force RTL mode (Right-to-left language)'), 1, $values['rtl']) ?><br/>
+    <?php echo Miniflux\Helper\form_checkbox('download_content', t('Download full content'), 1, $values['download_content']) ?><br/>
+    <?php echo Miniflux\Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
 
-    <p class="form-help"><?= t('Downloading full content is slower because Miniflux grab the content from the original website. You should use that for subscriptions that display only a summary. This feature doesn\'t work with all websites.') ?></p>
+    <p class="form-help"><?php echo t('Downloading full content is slower because Miniflux grab the content from the original website. You should use that for subscriptions that display only a summary. This feature doesn\'t work with all websites.') ?></p>
 
-    <?= Miniflux\Helper\form_label(t('Groups'), 'groups'); ?>
+    <?php echo Miniflux\Helper\form_label(t('Groups'), 'groups'); ?>
 
     <div id="grouplist">
         <?php foreach ($groups as $group): ?>
-            <?= Miniflux\Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
+            <?php echo Miniflux\Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
         <?php endforeach ?>
-        <?= Miniflux\Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
+        <?php echo Miniflux\Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
     </div>
 
     <div class="form-actions">
-        <button type="submit" class="btn btn-blue"><?= t('Add') ?></button>
-        <?= t('or') ?> <a href="?action=feeds"><?= t('cancel') ?></a>
+        <button type="submit" class="btn btn-blue"><?php echo t('Add') ?></button>
+        <?php echo t('or') ?> <a href="?action=feeds"><?php echo t('cancel') ?></a>
     </div>
 </form>

--- a/app/templates/api.php
+++ b/app/templates/api.php
@@ -1,31 +1,31 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li class="active"><a href="?action=api"><?= t('api') ?></a></li>
-            <li><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li class="active"><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 <section>
     <div class="panel panel-default">
-        <h3 id="fever"><?= t('Fever API') ?></h3>
+        <h3 id="fever"><?php echo t('Fever API') ?></h3>
         <ul>
-            <li><?= t('API endpoint:') ?> <strong><?= Miniflux\Helper\get_current_base_url(), 'fever/' ?></strong></li>
-            <li><?= t('API username:') ?> <strong><?= Miniflux\Helper\escape($config['username']) ?></strong></li>
-            <li><?= t('API token:') ?> <strong><?= Miniflux\Helper\escape($config['fever_token']) ?></strong></li>
+            <li><?php echo t('API endpoint:') ?> <strong><?php echo Miniflux\Helper\get_current_base_url(), 'fever/' ?></strong></li>
+            <li><?php echo t('API username:') ?> <strong><?php echo Miniflux\Helper\escape($config['username']) ?></strong></li>
+            <li><?php echo t('API token:') ?> <strong><?php echo Miniflux\Helper\escape($config['fever_token']) ?></strong></li>
         </ul>
     </div>
     <div class="panel panel-default">
-        <h3 id="api"><?= t('Miniflux API') ?></h3>
+        <h3 id="api"><?php echo t('Miniflux API') ?></h3>
         <ul>
-            <li><?= t('API endpoint:') ?> <strong><?= Miniflux\Helper\get_current_base_url(), 'jsonrpc.php' ?></strong></li>
-            <li><?= t('API username:') ?> <strong><?= Miniflux\Helper\escape($config['username']) ?></strong></li>
-            <li><?= t('API token:') ?> <strong><?= Miniflux\Helper\escape($config['api_token']) ?></strong></li>
+            <li><?php echo t('API endpoint:') ?> <strong><?php echo Miniflux\Helper\get_current_base_url(), 'jsonrpc.php' ?></strong></li>
+            <li><?php echo t('API username:') ?> <strong><?php echo Miniflux\Helper\escape($config['username']) ?></strong></li>
+            <li><?php echo t('API token:') ?> <strong><?php echo Miniflux\Helper\escape($config['api_token']) ?></strong></li>
         </ul>
     </div>
 </section>

--- a/app/templates/bookmark_links.php
+++ b/app/templates/bookmark_links.php
@@ -2,16 +2,16 @@
 <?php if ($item['bookmark']): ?>
     <a
         class="bookmark"
-        href="?action=bookmark&amp;value=0&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
+        href="?action=bookmark&amp;value=0&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
         data-action="bookmark"
-        data-reverse-label="<?= t('bookmark') ?>"
-    ><?= t('remove bookmark') ?></a>
+        data-reverse-label="<?php echo t('bookmark') ?>"
+    ><?php echo t('remove bookmark') ?></a>
 <?php else: ?>
     <a
         class="bookmark"
-        href="?action=bookmark&amp;value=1&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
+        href="?action=bookmark&amp;value=1&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
         data-action="bookmark"
-        data-reverse-label="<?= t('remove bookmark') ?>"
-    ><?= t('bookmark') ?></a>
+        data-reverse-label="<?php echo t('remove bookmark') ?>"
+    ><?php echo t('bookmark') ?></a>
 <?php endif ?>
 </li>

--- a/app/templates/bookmarks.php
+++ b/app/templates/bookmarks.php
@@ -1,15 +1,15 @@
 <?php if (empty($items) && $group_id === null): ?>
-    <p class="alert alert-info"><?= t('No bookmark') ?></p>
+    <p class="alert alert-info"><?php echo t('No bookmark') ?></p>
 <?php else: ?>
-    <?= Miniflux\Template\load('search_form') ?>
+    <?php echo Miniflux\Template\load('search_form') ?>
     <div class="page-header">
-        <h2><?= t('Bookmarks') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <h2><?php echo t('Bookmarks') ?><span id="page-counter"><?php echo isset($nb_items) ? $nb_items : '' ?></span></h2>
         <?php if (!empty($groups)): ?>
         <nav>
             <ul id="grouplist">
                 <?php foreach ($groups as $group): ?>
-                <li  <?= $group['id'] == $group_id ? 'class="active"' : '' ?>>
-                    <a href="?action=bookmarks&group_id=<?=$group['id']?>"><?=$group['title']?></a>
+                <li  <?php echo $group['id'] == $group_id ? 'class="active"' : '' ?>>
+                    <a href="?action=bookmarks&group_id=<?php echo$group['id']?>"><?php echo$group['title']?></a>
                 </li>
                 <?php endforeach ?>
             </ul>
@@ -19,12 +19,12 @@
     </div>
 
     <?php if ($nothing_to_read): ?>
-        <p class="alert alert-info"><?= t('There is nothing new to read, enjoy your favorites articles!') ?></p>
+        <p class="alert alert-info"><?php echo t('There is nothing new to read, enjoy your favorites articles!') ?></p>
     <?php endif ?>
 
     <section class="items" id="listing">
         <?php foreach ($items as $item): ?>
-            <?= Miniflux\Template\load('item', array(
+            <?php echo Miniflux\Template\load('item', array(
                 'item' => $item,
                 'menu' => $menu,
                 'offset' => $offset,
@@ -36,6 +36,6 @@
             )) ?>
         <?php endforeach ?>
 
-        <?= Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
+        <?php echo Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
     </section>
 <?php endif ?>

--- a/app/templates/config.php
+++ b/app/templates/config.php
@@ -1,99 +1,99 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li class="active"><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li class="active"><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 <section>
 <form method="post" action="?action=config" autocomplete="off" id="config-form">
 
-    <h3><?= t('Authentication') ?></h3>
+    <h3><?php echo t('Authentication') ?></h3>
     <div class="options">
-        <?= Miniflux\Helper\form_hidden('csrf', $values) ?>
-        <?= Miniflux\Helper\form_label(t('Username'), 'username') ?>
-        <?= Miniflux\Helper\form_text('username', $values, $errors, array('required')) ?><br/>
+        <?php echo Miniflux\Helper\form_hidden('csrf', $values) ?>
+        <?php echo Miniflux\Helper\form_label(t('Username'), 'username') ?>
+        <?php echo Miniflux\Helper\form_text('username', $values, $errors, array('required')) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Password'), 'password') ?>
-        <?= Miniflux\Helper\form_password('password', $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Password'), 'password') ?>
+        <?php echo Miniflux\Helper\form_password('password', $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Confirmation'), 'confirmation') ?>
-        <?= Miniflux\Helper\form_password('confirmation', $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Confirmation'), 'confirmation') ?>
+        <?php echo Miniflux\Helper\form_password('confirmation', $values, $errors) ?><br/>
     </div>
 
-    <h3><?= t('Application') ?></h3>
+    <h3><?php echo t('Application') ?></h3>
     <div class="options">
-        <?= Miniflux\Helper\form_label(t('Timezone'), 'timezone') ?>
-        <?= Miniflux\Helper\form_select('timezone', $timezones, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Timezone'), 'timezone') ?>
+        <?php echo Miniflux\Helper\form_select('timezone', $timezones, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Language'), 'language') ?>
-        <?= Miniflux\Helper\form_select('language', $languages, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Language'), 'language') ?>
+        <?php echo Miniflux\Helper\form_select('language', $languages, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Theme'), 'theme') ?>
-        <?= Miniflux\Helper\form_select('theme', $theme_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Theme'), 'theme') ?>
+        <?php echo Miniflux\Helper\form_select('theme', $theme_options, $values, $errors) ?><br/>
 
         <?php if (ENABLE_AUTO_UPDATE): ?>
-            <?= Miniflux\Helper\form_label(t('Auto-Update URL'), 'auto_update_url') ?>
-            <?= Miniflux\Helper\form_text('auto_update_url', $values, $errors, array('required')) ?><br/>
+            <?php echo Miniflux\Helper\form_label(t('Auto-Update URL'), 'auto_update_url') ?>
+            <?php echo Miniflux\Helper\form_text('auto_update_url', $values, $errors, array('required')) ?><br/>
         <?php endif ?>
 
-        <?= Miniflux\Helper\form_checkbox('debug_mode', t('Enable debug mode'), 1, isset($values['debug_mode']) && $values['debug_mode'] == 1) ?><br/>
+        <?php echo Miniflux\Helper\form_checkbox('debug_mode', t('Enable debug mode'), 1, isset($values['debug_mode']) && $values['debug_mode'] == 1) ?><br/>
 
-        <?= Miniflux\Helper\form_checkbox('image_proxy', t('Enable image proxy'), 1, isset($values['image_proxy']) && $values['image_proxy'] == 1) ?>
-        <div class="form-help"><?= t('Avoid mixed content warnings with HTTPS') ?></div>
+        <?php echo Miniflux\Helper\form_checkbox('image_proxy', t('Enable image proxy'), 1, isset($values['image_proxy']) && $values['image_proxy'] == 1) ?>
+        <div class="form-help"><?php echo t('Avoid mixed content warnings with HTTPS') ?></div>
     </div>
 
-    <h3><?= t('Reading') ?></h3>
+    <h3><?php echo t('Reading') ?></h3>
     <div class="options">
-        <?= Miniflux\Helper\form_label(t('Remove automatically read items'), 'autoflush') ?>
-        <?= Miniflux\Helper\form_select('autoflush', $autoflush_read_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Remove automatically read items'), 'autoflush') ?>
+        <?php echo Miniflux\Helper\form_select('autoflush', $autoflush_read_options, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Remove automatically unread items'), 'autoflush_unread') ?>
-        <?= Miniflux\Helper\form_select('autoflush_unread', $autoflush_unread_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Remove automatically unread items'), 'autoflush_unread') ?>
+        <?php echo Miniflux\Helper\form_select('autoflush_unread', $autoflush_unread_options, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Items per page'), 'items_per_page') ?>
-        <?= Miniflux\Helper\form_select('items_per_page', $paging_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Items per page'), 'items_per_page') ?>
+        <?php echo Miniflux\Helper\form_select('items_per_page', $paging_options, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Default sorting order for items'), 'items_sorting_direction') ?>
-        <?= Miniflux\Helper\form_select('items_sorting_direction', $sorting_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Default sorting order for items'), 'items_sorting_direction') ?>
+        <?php echo Miniflux\Helper\form_select('items_sorting_direction', $sorting_options, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Display items on lists'), 'items_display_mode') ?>
-        <?= Miniflux\Helper\form_select('items_display_mode', $display_mode, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Display items on lists'), 'items_display_mode') ?>
+        <?php echo Miniflux\Helper\form_select('items_display_mode', $display_mode, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Item title links to'), 'item_title_link') ?>
-        <?= Miniflux\Helper\form_select('item_title_link', $item_title_link, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Item title links to'), 'item_title_link') ?>
+        <?php echo Miniflux\Helper\form_select('item_title_link', $item_title_link, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('When there is nothing to read, redirect me to this page'), 'redirect_nothing_to_read') ?>
-        <?= Miniflux\Helper\form_select('redirect_nothing_to_read', $redirect_nothing_to_read_options, $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('When there is nothing to read, redirect me to this page'), 'redirect_nothing_to_read') ?>
+        <?php echo Miniflux\Helper\form_select('redirect_nothing_to_read', $redirect_nothing_to_read_options, $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Refresh interval in minutes for unread counter'), 'frontend_updatecheck_interval') ?>
-        <?= Miniflux\Helper\form_number('frontend_updatecheck_interval', $values, $errors, array('min="0"')) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Refresh interval in minutes for unread counter'), 'frontend_updatecheck_interval') ?>
+        <?php echo Miniflux\Helper\form_number('frontend_updatecheck_interval', $values, $errors, array('min="0"')) ?><br/>
 
-        <?= Miniflux\Helper\form_checkbox('original_marks_read', t('Original link marks article as read'), 1, isset($values['original_marks_read']) && $values['original_marks_read'] == 1) ?><br/>
-        <?= Miniflux\Helper\form_checkbox('nocontent', t('Do not fetch the content of articles'), 1, isset($values['nocontent']) && $values['nocontent'] == 1) ?><br/>
-        <?= Miniflux\Helper\form_checkbox('favicons', t('Download favicons'), 1, isset($values['favicons']) && $values['favicons'] == 1) ?><br/>
+        <?php echo Miniflux\Helper\form_checkbox('original_marks_read', t('Original link marks article as read'), 1, isset($values['original_marks_read']) && $values['original_marks_read'] == 1) ?><br/>
+        <?php echo Miniflux\Helper\form_checkbox('nocontent', t('Do not fetch the content of articles'), 1, isset($values['nocontent']) && $values['nocontent'] == 1) ?><br/>
+        <?php echo Miniflux\Helper\form_checkbox('favicons', t('Download favicons'), 1, isset($values['favicons']) && $values['favicons'] == 1) ?><br/>
     </div>
 
     <div class="form-actions">
-        <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
+        <input type="submit" value="<?php echo t('Save') ?>" class="btn btn-blue"/>
     </div>
 </form>
 </section>
 
 <div class="page-section">
-    <h2><?= t('Advanced') ?></h2>
+    <h2><?php echo t('Advanced') ?></h2>
 </div>
 <section class="panel panel-danger">
 <ul>
-    <li><a href="?action=generate-tokens&amp;csrf=<?= $values['csrf'] ?>"><?= t('Generate new tokens') ?></a> (<?= t('Miniflux API') ?>, <?= t('Fever API') ?>, <?= t('Bookmarklet') ?>, <?= t('Bookmark RSS Feed') ?>)</li>
+    <li><a href="?action=generate-tokens&amp;csrf=<?php echo $values['csrf'] ?>"><?php echo t('Generate new tokens') ?></a> (<?php echo t('Miniflux API') ?>, <?php echo t('Fever API') ?>, <?php echo t('Bookmarklet') ?>, <?php echo t('Bookmark RSS Feed') ?>)</li>
 <?php if (ENABLE_AUTO_UPDATE): ?>
-    <li><a href="?action=confirm-auto-update"><?= t('Update Miniflux') ?></a> (<?= t('Don\'t forget to backup your database') ?>)</li>
+    <li><a href="?action=confirm-auto-update"><?php echo t('Update Miniflux') ?></a> (<?php echo t('Don\'t forget to backup your database') ?>)</li>
 <?php endif ?>
 </ul>
 </section>

--- a/app/templates/confirm_auto_update.php
+++ b/app/templates/confirm_auto_update.php
@@ -1,10 +1,10 @@
 <div class="page-header">
-    <h2><?= t('Confirmation') ?></h2>
+    <h2><?php echo t('Confirmation') ?></h2>
 </div>
 
-<p class="alert alert-info"><?= t('This action will update Miniflux with the last development version, are you sure?') ?></p>
+<p class="alert alert-info"><?php echo t('This action will update Miniflux with the last development version, are you sure?') ?></p>
 
 <div class="form-actions">
-    <a href="?action=auto-update" class="btn btn-red"><?= t('Update Miniflux') ?></a>
-    <?= t('or') ?> <a href="?action=config"><?= t('cancel') ?></a>
+    <a href="?action=auto-update" class="btn btn-red"><?php echo t('Update Miniflux') ?></a>
+    <?php echo t('or') ?> <a href="?action=config"><?php echo t('cancel') ?></a>
 </div>

--- a/app/templates/confirm_flush_items.php
+++ b/app/templates/confirm_flush_items.php
@@ -1,10 +1,10 @@
 <div class="page-header">
-    <h2><?= t('Confirmation') ?></h2>
+    <h2><?php echo t('Confirmation') ?></h2>
 </div>
 
-<p class="alert alert-info"><?= t('Do you really want to remove these items from your history?') ?></p>
+<p class="alert alert-info"><?php echo t('Do you really want to remove these items from your history?') ?></p>
 
 <div class="form-actions">
-    <a href="?action=flush-history<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>" class="btn btn-red"><?= t('Remove') ?></a>
-    <?= t('or') ?> <a href="?action=history<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?= t('cancel') ?></a>
+    <a href="?action=flush-history<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>" class="btn btn-red"><?php echo t('Remove') ?></a>
+    <?php echo t('or') ?> <a href="?action=history<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?php echo t('cancel') ?></a>
 </div>

--- a/app/templates/confirm_remove_feed.php
+++ b/app/templates/confirm_remove_feed.php
@@ -1,10 +1,10 @@
 <div class="page-header">
-    <h2><?= t('Confirmation') ?></h2>
+    <h2><?php echo t('Confirmation') ?></h2>
 </div>
 
-<p class="alert alert-info"><?= t('Do you really want to remove this subscription: "%s"?', Miniflux\Helper\escape($feed['title'])) ?></p>
+<p class="alert alert-info"><?php echo t('Do you really want to remove this subscription: "%s"?', Miniflux\Helper\escape($feed['title'])) ?></p>
 
 <div class="form-actions">
-    <a href="?action=remove-feed&amp;feed_id=<?= $feed['id'] ?>" class="btn btn-red"><?= t('Remove') ?></a>
-    <?= t('or') ?> <a href="?action=feeds"><?= t('cancel') ?></a>
+    <a href="?action=remove-feed&amp;feed_id=<?php echo $feed['id'] ?>" class="btn btn-red"><?php echo t('Remove') ?></a>
+    <?php echo t('or') ?> <a href="?action=feeds"><?php echo t('cancel') ?></a>
 </div>

--- a/app/templates/console.php
+++ b/app/templates/console.php
@@ -1,13 +1,13 @@
 <div class="page-header">
-    <h2><?= t('Console') ?></h2>
+    <h2><?php echo t('Console') ?></h2>
     <ul>
-        <li><a href="?action=console"><?= t('refresh') ?></a></li>
-        <li><a href="?action=flush-console"><?= t('flush messages') ?></a></li>
+        <li><a href="?action=console"><?php echo t('refresh') ?></a></li>
+        <li><a href="?action=flush-console"><?php echo t('flush messages') ?></a></li>
     </ul>
 </div>
 
 <?php if (empty($content)): ?>
-    <p class="alert alert-info"><?= t('Nothing to show. Enable the debug mode to see log messages.') ?></p>
+    <p class="alert alert-info"><?php echo t('Nothing to show. Enable the debug mode to see log messages.') ?></p>
 <?php else: ?>
-    <pre id="console"><code><?= Miniflux\Helper\escape($content) ?></code></pre>
+    <pre id="console"><code><?php echo Miniflux\Helper\escape($content) ?></code></pre>
 <?php endif ?>

--- a/app/templates/database.php
+++ b/app/templates/database.php
@@ -1,25 +1,25 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li class="active"><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li class="active"><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 <section>
     <div class="panel panel-default">
         <ul>
-            <li><?= t('Database size:') ?> <strong><?= Miniflux\Helper\format_bytes($db_size) ?></strong></li>
-            <li><a href="?action=optimize-db&amp;csrf=<?= $csrf ?>"><?= t('Optimize the database') ?></a> <?= t('(VACUUM command)') ?></li>
-            <li><a href="?action=download-db&amp;csrf=<?= $csrf ?>"><?= t('Download the entire database') ?></a> <?= t('(Gzip compressed Sqlite file)') ?></li>
+            <li><?php echo t('Database size:') ?> <strong><?php echo Miniflux\Helper\format_bytes($db_size) ?></strong></li>
+            <li><a href="?action=optimize-db&amp;csrf=<?php echo $csrf ?>"><?php echo t('Optimize the database') ?></a> <?php echo t('(VACUUM command)') ?></li>
+            <li><a href="?action=download-db&amp;csrf=<?php echo $csrf ?>"><?php echo t('Download the entire database') ?></a> <?php echo t('(Gzip compressed Sqlite file)') ?></li>
             <?php if (ENABLE_MULTIPLE_DB): ?>
             <li>
-                <a href="?action=new-db"><?= t('Add a new database (new user)') ?></a>
+                <a href="?action=new-db"><?php echo t('Add a new database (new user)') ?></a>
             </li>
             <?php endif ?>
         </ul>

--- a/app/templates/edit_feed.php
+++ b/app/templates/edit_feed.php
@@ -1,48 +1,48 @@
 <div class="page-header">
-    <h2><?= t('Edit subscription') ?></h2>
+    <h2><?php echo t('Edit subscription') ?></h2>
     <ul>
-        <li><a href="?action=add"><?= t('add') ?></a></li>
-        <li><a href="?action=feeds"><?= t('feeds') ?></a></li>
-        <li><a href="?action=import"><?= t('import') ?></a></li>
-        <li><a href="?action=export"><?= t('export') ?></a></li>
+        <li><a href="?action=add"><?php echo t('add') ?></a></li>
+        <li><a href="?action=feeds"><?php echo t('feeds') ?></a></li>
+        <li><a href="?action=import"><?php echo t('import') ?></a></li>
+        <li><a href="?action=export"><?php echo t('export') ?></a></li>
     </ul>
 </div>
 
 <form method="post" action="?action=edit-feed" autocomplete="off">
 
-    <?= Miniflux\Helper\form_hidden('id', $values) ?>
+    <?php echo Miniflux\Helper\form_hidden('id', $values) ?>
 
-    <?= Miniflux\Helper\form_label(t('Title'), 'title') ?>
-    <?= Miniflux\Helper\form_text('title', $values, $errors, array('required')) ?>
+    <?php echo Miniflux\Helper\form_label(t('Title'), 'title') ?>
+    <?php echo Miniflux\Helper\form_text('title', $values, $errors, array('required')) ?>
 
-    <?= Miniflux\Helper\form_label(t('Website URL'), 'site_url') ?>
-    <?= Miniflux\Helper\form_text('site_url', $values, $errors, array('required', 'placeholder="http://..."')) ?>
+    <?php echo Miniflux\Helper\form_label(t('Website URL'), 'site_url') ?>
+    <?php echo Miniflux\Helper\form_text('site_url', $values, $errors, array('required', 'placeholder="http://..."')) ?>
 
-    <?= Miniflux\Helper\form_label(t('Feed URL'), 'feed_url') ?>
-    <?= Miniflux\Helper\form_text('feed_url', $values, $errors, array('required', 'placeholder="http://..."')) ?>
+    <?php echo Miniflux\Helper\form_label(t('Feed URL'), 'feed_url') ?>
+    <?php echo Miniflux\Helper\form_text('feed_url', $values, $errors, array('required', 'placeholder="http://..."')) ?>
 
-    <?= Miniflux\Helper\form_checkbox('rtl', t('Force RTL mode (Right-to-left language)'), 1, $values['rtl']) ?><br />
+    <?php echo Miniflux\Helper\form_checkbox('rtl', t('Force RTL mode (Right-to-left language)'), 1, $values['rtl']) ?><br />
 
-    <?= Miniflux\Helper\form_checkbox('download_content', t('Download full content'), 1, $values['download_content']) ?><br />
+    <?php echo Miniflux\Helper\form_checkbox('download_content', t('Download full content'), 1, $values['download_content']) ?><br />
 
-    <?= Miniflux\Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
+    <?php echo Miniflux\Helper\form_checkbox('cloak_referrer', t('Cloak the image referrer'), 1, $values['cloak_referrer']) ?><br />
 
-    <?= Miniflux\Helper\form_checkbox('enabled', t('Activated'), 1, $values['enabled']) ?><br />
+    <?php echo Miniflux\Helper\form_checkbox('enabled', t('Activated'), 1, $values['enabled']) ?><br />
 
-    <?= Miniflux\Helper\form_label(t('Groups'), 'groups'); ?>
+    <?php echo Miniflux\Helper\form_label(t('Groups'), 'groups'); ?>
 
     <div id="grouplist">
         <?php foreach ($groups as $group): ?>
-            <?= Miniflux\Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
+            <?php echo Miniflux\Helper\form_checkbox('feed_group_ids[]', $group['title'], $group['id'], in_array($group['id'], $values['feed_group_ids']), 'hide') ?>
         <?php endforeach ?>
-        <?= Miniflux\Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
+        <?php echo Miniflux\Helper\form_text('create_group', $values, array(), array('placeholder="'.t('add a new group').'"')) ?>
     </div>
 
     <div class="form-actions">
-        <button type="submit" class="btn btn-blue"><?= t('Save') ?></button>
-        <?= t('or') ?> <a href="?action=feeds"><?= t('cancel') ?></a>
+        <button type="submit" class="btn btn-blue"><?php echo t('Save') ?></button>
+        <?php echo t('or') ?> <a href="?action=feeds"><?php echo t('cancel') ?></a>
     </div>
 </form>
 <div class="form-actions">
-    <a href="?action=confirm-remove-feed&amp;feed_id=<?= $values['id'] ?>" class="btn btn-red"><?= t('Remove this feed') ?></a>
+    <a href="?action=confirm-remove-feed&amp;feed_id=<?php echo $values['id'] ?>" class="btn btn-red"><?php echo t('Remove this feed') ?></a>
 </div>

--- a/app/templates/feed_items.php
+++ b/app/templates/feed_items.php
@@ -1,36 +1,36 @@
 <?php if (empty($items)): ?>
     <p class="alert alert-info">
-        <?= tne('This subscription is empty, %sgo back to unread items%s','<a href="?action=unread">','</a>') ?>
+        <?php echo tne('This subscription is empty, %sgo back to unread items%s','<a href="?action=unread">','</a>') ?>
     </p>
 <?php else: ?>
 
     <div class="page-header">
-        <h2><?= Miniflux\Helper\escape($feed['title']) ?>&lrm;<span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <h2><?php echo Miniflux\Helper\escape($feed['title']) ?>&lrm;<span id="page-counter"><?php echo isset($nb_items) ? $nb_items : '' ?></span></h2>
         <ul>
             <li>
-                <a href="?action=refresh-feed&amp;feed_id=<?= $feed['id'] ?>&amp;redirect=feed-items"><?= t('refresh') ?></a>
+                <a href="?action=refresh-feed&amp;feed_id=<?php echo $feed['id'] ?>&amp;redirect=feed-items"><?php echo t('refresh') ?></a>
             </li>
             <li>
-                <a href="?action=edit-feed&amp;feed_id=<?= $feed['id'] ?>"><?= t('edit') ?></a>
+                <a href="?action=edit-feed&amp;feed_id=<?php echo $feed['id'] ?>"><?php echo t('edit') ?></a>
             </li>
             <li>
-                <a href="?action=feed-items&amp;feed_id=<?= $feed['id'] ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">', $direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
+                <a href="?action=feed-items&amp;feed_id=<?php echo $feed['id'] ?>&amp;order=updated&amp;direction=<?php echo $direction == 'asc' ? 'desc' : 'asc' ?>"><?php echo tne('sort by date %s(%s)%s', '<span class="hide-mobile">', $direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
             <li>
-                <a href="?action=mark-feed-as-read&amp;feed_id=<?= $feed['id'] ?>" data-action="mark-feed-read"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-feed-as-read&amp;feed_id=<?php echo $feed['id'] ?>" data-action="mark-feed-read"><?php echo t('mark all as read') ?></a>
             </li>
         </ul>
     </div>
 
     <?php if ($feed['parsing_error']): ?>
         <p class="alert alert-error">
-            <?= tne('An error occurred during the last check. Refresh the feed manually and check the %sconsole%s for errors afterwards!','<a href="?action=console">','</a>') ?>
+            <?php echo tne('An error occurred during the last check. Refresh the feed manually and check the %sconsole%s for errors afterwards!','<a href="?action=console">','</a>') ?>
         </p>
     <?php endif; ?>
 
-    <section class="items" id="listing" data-feed-id="<?= $feed['id'] ?>">
+    <section class="items" id="listing" data-feed-id="<?php echo $feed['id'] ?>">
         <?php foreach ($items as $item): ?>
-            <?= Miniflux\Template\load('item', array(
+            <?php echo Miniflux\Template\load('item', array(
                 'feed' => $feed,
                 'item' => $item,
                 'menu' => $menu,
@@ -44,10 +44,10 @@
         <?php endforeach ?>
 
         <div id="bottom-menu">
-            <a href="?action=mark-feed-as-read&amp;feed_id=<?= $feed['id'] ?>" data-action="mark-feed-read"><?= t('mark all as read') ?></a>
+            <a href="?action=mark-feed-as-read&amp;feed_id=<?php echo $feed['id'] ?>" data-action="mark-feed-read"><?php echo t('mark all as read') ?></a>
         </div>
 
-        <?= Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'feed_id' => $feed['id'])) ?>
+        <?php echo Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'feed_id' => $feed['id'])) ?>
     </section>
 
 <?php endif ?>

--- a/app/templates/feeds.php
+++ b/app/templates/feeds.php
@@ -1,73 +1,73 @@
 <div class="page-header">
-    <h2><?= t('Subscriptions') ?></h2>
+    <h2><?php echo t('Subscriptions') ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=add"><?= t('add') ?></a></li>
-            <li class="active"><a href="?action=feeds"><?= t('feeds') ?></a></li>
-            <li><a href="?action=import"><?= t('import') ?></a></li>
-            <li><a href="?action=export"><?= t('export') ?></a></li>
-            <li><a href="?action=refresh-all" data-action="refresh-all" data-concurrent-requests="<?= SUBSCRIPTION_CONCURRENT_REQUESTS ?>"><?= t('refresh all') ?></a></li>
+            <li><a href="?action=add"><?php echo t('add') ?></a></li>
+            <li class="active"><a href="?action=feeds"><?php echo t('feeds') ?></a></li>
+            <li><a href="?action=import"><?php echo t('import') ?></a></li>
+            <li><a href="?action=export"><?php echo t('export') ?></a></li>
+            <li><a href="?action=refresh-all" data-action="refresh-all" data-concurrent-requests="<?php echo SUBSCRIPTION_CONCURRENT_REQUESTS ?>"><?php echo t('refresh all') ?></a></li>
         </ul>
     </nav>
 </div>
 
 <?php if (empty($feeds)): ?>
 
-    <p class="alert alert-info"><?= t('No subscription') ?></p>
+    <p class="alert alert-info"><?php echo t('No subscription') ?></p>
 
 <?php else: ?>
 
     <?php if ($nb_failed_feeds > 0): ?>
-        <p class="alert alert-error"><?= tne('An error occurred during the last check. Refresh the feed manually and check the %sconsole%s for errors afterwards!', '<a href="?action=console">', '</a>') ?></p>
+        <p class="alert alert-error"><?php echo tne('An error occurred during the last check. Refresh the feed manually and check the %sconsole%s for errors afterwards!', '<a href="?action=console">', '</a>') ?></p>
     <?php elseif ($nothing_to_read): ?>
-        <p class="alert alert-info"><?= tne('Nothing to read, do you want to %supdate your subscriptions%s?','<a href="?action=refresh-all" data-action="refresh-all">','</a>') ?></p>
+        <p class="alert alert-info"><?php echo tne('Nothing to read, do you want to %supdate your subscriptions%s?','<a href="?action=refresh-all" data-action="refresh-all">','</a>') ?></p>
     <?php endif ?>
 
     <section class="items">
     <?php foreach ($feeds as $feed): ?>
-        <article data-feed-id="<?= $feed['id'] ?>" <?= (! $feed['enabled']) ? 'data-feed-disabled="1"' : '' ?> <?= ($feed['parsing_error']) ? 'data-feed-error="1"' : '' ?>>
+        <article data-feed-id="<?php echo $feed['id'] ?>" <?php echo (! $feed['enabled']) ? 'data-feed-disabled="1"' : '' ?> <?php echo ($feed['parsing_error']) ? 'data-feed-error="1"' : '' ?>>
             <h2>
                 <?php if (! $feed['enabled']): ?>
-                    <span title="<?= t('Subscription disabled') ?>">✖</span>
+                    <span title="<?php echo t('Subscription disabled') ?>">✖</span>
                 <?php endif ?>
 
-                <?= Miniflux\Helper\favicon($favicons, $feed['id']) ?>
+                <?php echo Miniflux\Helper\favicon($favicons, $feed['id']) ?>
 
-                <a href="?action=feed-items&amp;feed_id=<?= $feed['id'] ?>" title="<?= t('Show only this subscription') ?>"><?= Miniflux\Helper\escape($feed['title']) ?></a>
-                &lrm;<span class="items-count"><?= $feed['items_unread'], '/', $feed['items_total'] ?></span>
+                <a href="?action=feed-items&amp;feed_id=<?php echo $feed['id'] ?>" title="<?php echo t('Show only this subscription') ?>"><?php echo Miniflux\Helper\escape($feed['title']) ?></a>
+                &lrm;<span class="items-count"><?php echo $feed['items_unread'], '/', $feed['items_total'] ?></span>
 
                 <?php if ($feed['enabled']): ?>
 
                     <br/>
 
                     <?php if ($feed['last_checked']): ?>
-                        <time class="feed-last-checked" data-after-update="<?= t('updated just now') ?>">
-                            <?= t('checked at'), ' ', dt('%e %B %Y %k:%M', $feed['last_checked']) ?>
+                        <time class="feed-last-checked" data-after-update="<?php echo t('updated just now') ?>">
+                            <?php echo t('checked at'), ' ', dt('%e %B %Y %k:%M', $feed['last_checked']) ?>
                         </time>
                     <?php else: ?>
-                        <span class="feed-last-checked" data-after-update="<?= t('updated just now') ?>">
-                            <?= t('never updated after creation') ?>
+                        <span class="feed-last-checked" data-after-update="<?php echo t('updated just now') ?>">
+                            <?php echo t('never updated after creation') ?>
                         </span>
                     <?php endif ?>
 
                     <span class="feed-parsing-error">
-                            <?= t('(error occurred during the last check)') ?>
+                            <?php echo t('(error occurred during the last check)') ?>
                     </span>
 
                 <?php endif ?>
             </h2>
             <ul class="item-menu">
                 <li>
-                    <a href="<?= $feed['site_url'] ?>" rel="noreferrer" target="_blank"><?= Miniflux\Helper\get_host_from_url($feed['site_url']) ?></a>
+                    <a href="<?php echo $feed['site_url'] ?>" rel="noreferrer" target="_blank"><?php echo Miniflux\Helper\get_host_from_url($feed['site_url']) ?></a>
                 </li>
 
                 <?php if ($feed['enabled']): ?>
                 <li>
-                    <a href="?action=refresh-feed&amp;feed_id=<?= $feed['id'] ?>" data-action="refresh-feed"><?= t('refresh') ?></a>
+                    <a href="?action=refresh-feed&amp;feed_id=<?php echo $feed['id'] ?>" data-action="refresh-feed"><?php echo t('refresh') ?></a>
                 </li>
                 <?php endif ?>
 
-                <li><a href="?action=edit-feed&amp;feed_id=<?= $feed['id'] ?>"><?= t('edit') ?></a></li>
+                <li><a href="?action=edit-feed&amp;feed_id=<?php echo $feed['id'] ?>"><?php echo t('edit') ?></a></li>
             </ul>
         </article>
     <?php endforeach ?>

--- a/app/templates/help.php
+++ b/app/templates/help.php
@@ -1,35 +1,35 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li><a href="?action=database"><?= t('database') ?></a></li>
-            <li class="active"><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li class="active"><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 <section>
-    <?= Miniflux\Template\load('keyboard_shortcuts') ?>
+    <?php echo Miniflux\Template\load('keyboard_shortcuts') ?>
 </section>
 <div class="page-section">
-    <h2><?= t('Documentation') ?></h2>
+    <h2><?php echo t('Documentation') ?></h2>
 </div>
 <section>
 <ul>
-    <li><a href="https://miniflux.net/documentation/installation" rel="noreferrer" target="_blank"><?= t('Installation instructions') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/upgrade" rel="noreferrer" target="_blank"><?= t('Upgrade to a new version') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/cronjob" rel="noreferrer" target="_blank"><?= t('Cronjob') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/config" rel="noreferrer" target="_blank"><?= t('Advanced configuration') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/full-article-download" rel="noreferrer" target="_blank"><?= t('Full article download') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/multiple-users" rel="noreferrer" target="_blank"><?= t('Multiple users') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/themes" rel="noreferrer" target="_blank"><?= t('Themes') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/json-rpc-api" rel="noreferrer" target="_blank"><?= t('Json-RPC API') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/fever" rel="noreferrer" target="_blank"><?= t('Fever API') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/translations" rel="noreferrer" target="_blank"><?= t('Translations') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/docker" rel="noreferrer" target="_blank"><?= t('Run Miniflux with Docker') ?></a></li>
-    <li><a href="https://miniflux.net/documentation/faq" rel="noreferrer" target="_blank"><?= t('FAQ') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/installation" rel="noreferrer" target="_blank"><?php echo t('Installation instructions') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/upgrade" rel="noreferrer" target="_blank"><?php echo t('Upgrade to a new version') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/cronjob" rel="noreferrer" target="_blank"><?php echo t('Cronjob') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/config" rel="noreferrer" target="_blank"><?php echo t('Advanced configuration') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/full-article-download" rel="noreferrer" target="_blank"><?php echo t('Full article download') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/multiple-users" rel="noreferrer" target="_blank"><?php echo t('Multiple users') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/themes" rel="noreferrer" target="_blank"><?php echo t('Themes') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/json-rpc-api" rel="noreferrer" target="_blank"><?php echo t('Json-RPC API') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/fever" rel="noreferrer" target="_blank"><?php echo t('Fever API') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/translations" rel="noreferrer" target="_blank"><?php echo t('Translations') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/docker" rel="noreferrer" target="_blank"><?php echo t('Run Miniflux with Docker') ?></a></li>
+    <li><a href="https://miniflux.net/documentation/faq" rel="noreferrer" target="_blank"><?php echo t('FAQ') ?></a></li>
 </ul>
 </section>

--- a/app/templates/help_layer.php
+++ b/app/templates/help_layer.php
@@ -1,6 +1,6 @@
 <div id="help-layer" class="hide">
     <span class="btn-close" data-action="close-help">&times;</span>
     <section>
-        <?= Miniflux\Template\load('keyboard_shortcuts') ?>
+        <?php echo Miniflux\Template\load('keyboard_shortcuts') ?>
     </section>
 </div>

--- a/app/templates/history.php
+++ b/app/templates/history.php
@@ -1,15 +1,15 @@
 <?php if (empty($items)): ?>
-    <p class="alert alert-info"><?= t('No history') ?></p>
+    <p class="alert alert-info"><?php echo t('No history') ?></p>
 <?php else: ?>
-    <?= Miniflux\Template\load('search_form') ?>
+    <?php echo Miniflux\Template\load('search_form') ?>
     <div class="page-header">
-        <h2><?= t('History') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <h2><?php echo t('History') ?><span id="page-counter"><?php echo isset($nb_items) ? $nb_items : '' ?></span></h2>
         <?php if (!empty($groups)): ?>
         <nav>
             <ul id="grouplist">
                 <?php foreach ($groups as $group): ?>
-                <li  <?= $group['id'] == $group_id ? 'class="active"' : '' ?>>
-                    <a href="?action=history&group_id=<?=$group['id']?>"><?=$group['title']?></a>
+                <li  <?php echo $group['id'] == $group_id ? 'class="active"' : '' ?>>
+                    <a href="?action=history&group_id=<?php echo$group['id']?>"><?php echo$group['title']?></a>
                 </li>
                 <?php endforeach ?>
             </ul>
@@ -18,19 +18,19 @@
 
         <ul>
             <li>
-                <a href="?action=history<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">', $direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
+                <a href="?action=history<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?php echo $direction == 'asc' ? 'desc' : 'asc' ?>"><?php echo tne('sort by date %s(%s)%s', '<span class="hide-mobile">', $direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
-            <li><a href="?action=confirm-flush-history<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?= t('flush all items') ?></a></li>
+            <li><a href="?action=confirm-flush-history<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?php echo t('flush all items') ?></a></li>
         </ul>
     </div>
 
     <?php if ($nothing_to_read): ?>
-        <p class="alert alert-info"><?= t('There is nothing new to read, enjoy your previous readings!') ?></p>
+        <p class="alert alert-info"><?php echo t('There is nothing new to read, enjoy your previous readings!') ?></p>
     <?php endif ?>
 
     <section class="items" id="listing">
         <?php foreach ($items as $item): ?>
-            <?= Miniflux\Template\load('item', array(
+            <?php echo Miniflux\Template\load('item', array(
                 'item' => $item,
                 'menu' => $menu,
                 'offset' => $offset,
@@ -42,7 +42,7 @@
             )) ?>
         <?php endforeach ?>
 
-        <?= Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
+        <?php echo Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
     </section>
 
 <?php endif ?>

--- a/app/templates/import.php
+++ b/app/templates/import.php
@@ -1,20 +1,20 @@
 <div class="page-header">
-    <h2><?= t('OPML Import') ?></h2>
+    <h2><?php echo t('OPML Import') ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=add"><?= t('add') ?></a></li>
-            <li><a href="?action=feeds"><?= t('feeds') ?></a></li>
-            <li class="active"><a href="?action=import"><?= t('import') ?></a></li>
-            <li><a href="?action=export"><?= t('export') ?></a></li>
+            <li><a href="?action=add"><?php echo t('add') ?></a></li>
+            <li><a href="?action=feeds"><?php echo t('feeds') ?></a></li>
+            <li class="active"><a href="?action=import"><?php echo t('import') ?></a></li>
+            <li><a href="?action=export"><?php echo t('export') ?></a></li>
         </ul>
     </nav>
 </div>
 
 <form method="post" action="?action=import" enctype="multipart/form-data">
-    <label for="file"><?= t('OPML file') ?></label>
+    <label for="file"><?php echo t('OPML file') ?></label>
     <input type="file" name="file" required/>
     <div class="form-actions">
-        <button type="submit" class="btn btn-blue"><?= t('Import') ?></button>
-        <?= t('or') ?> <a href="?action=feeds"><?= t('cancel') ?></a>
+        <button type="submit" class="btn btn-blue"><?php echo t('Import') ?></button>
+        <?php echo t('or') ?> <a href="?action=feeds"><?php echo t('cancel') ?></a>
     </div>
 </form>

--- a/app/templates/item.php
+++ b/app/templates/item.php
@@ -1,42 +1,42 @@
 <article
-    id="item-<?= $item['id'] ?>"
-    class="feed-<?= $item['feed_id'] ?>"
-    data-item-id="<?= $item['id'] ?>"
-    data-item-status="<?= $item['status'] ?>"
-    data-item-bookmark="<?= $item['bookmark'] ?>"
-    <?= $hide ? 'data-hide="true"' : '' ?>
+    id="item-<?php echo $item['id'] ?>"
+    class="feed-<?php echo $item['feed_id'] ?>"
+    data-item-id="<?php echo $item['id'] ?>"
+    data-item-status="<?php echo $item['status'] ?>"
+    data-item-bookmark="<?php echo $item['bookmark'] ?>"
+    <?php echo $hide ? 'data-hide="true"' : '' ?>
     >
-    <h2 <?= Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>>
+    <h2 <?php echo Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>>
         <span class="item-icons">
             <a
                 class="bookmark-icon"
-                href="?action=bookmark&amp;value=<?= (int)!$item['bookmark'] ?>&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
-                title="<?= ($item['bookmark']) ? t('remove bookmark') : t('bookmark') ?>"
+                href="?action=bookmark&amp;value=<?php echo (int)!$item['bookmark'] ?>&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
+                title="<?php echo ($item['bookmark']) ? t('remove bookmark') : t('bookmark') ?>"
                 data-action="bookmark"
-                data-reverse-title="<?= ($item['bookmark']) ? t('bookmark') : t('remove bookmark') ?>"
+                data-reverse-title="<?php echo ($item['bookmark']) ? t('bookmark') : t('remove bookmark') ?>"
             ></a>
             <a
                 class="read-icon"
-                href="?action=<?= ($item['status'] === 'unread') ? 'mark-item-read' : 'mark-item-unread' ?>&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
-                title="<?= ($item['status'] === 'unread') ? t('mark as read') : t('mark as unread') ?>"
-                data-action="<?= ($item['status'] === 'unread') ? 'mark-read' : 'mark-unread' ?>"
-                data-reverse-title="<?= ($item['status'] === 'unread') ? t('mark as unread') : t('mark as read') ?>"
+                href="?action=<?php echo ($item['status'] === 'unread') ? 'mark-item-read' : 'mark-item-unread' ?>&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
+                title="<?php echo ($item['status'] === 'unread') ? t('mark as read') : t('mark as unread') ?>"
+                data-action="<?php echo ($item['status'] === 'unread') ? 'mark-read' : 'mark-unread' ?>"
+                data-reverse-title="<?php echo ($item['status'] === 'unread') ? t('mark as unread') : t('mark as read') ?>"
             ></a>
         </span>
         <span class="item-title">
-        <?= Miniflux\Helper\favicon($favicons, $item['feed_id']) ?>
+        <?php echo Miniflux\Helper\favicon($favicons, $item['feed_id']) ?>
         <?php if ($display_mode === 'full' || $item_title_link == 'original'): ?>
             <a class="original" rel="noreferrer" target="_blank"
-               href="<?= $item['url'] ?>"
-               <?= ($original_marks_read) ? 'data-action="mark-read"' : '' ?>
-               title="<?= Miniflux\Helper\escape($item['title']) ?>"
-            ><?= Miniflux\Helper\escape($item['title']) ?></a>
+               href="<?php echo $item['url'] ?>"
+               <?php echo ($original_marks_read) ? 'data-action="mark-read"' : '' ?>
+               title="<?php echo Miniflux\Helper\escape($item['title']) ?>"
+            ><?php echo Miniflux\Helper\escape($item['title']) ?></a>
         <?php else: ?>
             <a
-                href="?action=show&amp;menu=<?= $menu ?><?= isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item['id'] ?>"
+                href="?action=show&amp;menu=<?php echo $menu ?><?php echo isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item['id'] ?>"
                 class="show"
-                title="<?= Miniflux\Helper\escape($item['title']) ?>"
-            ><?= Miniflux\Helper\escape($item['title']) ?></a>
+                title="<?php echo Miniflux\Helper\escape($item['title']) ?>"
+            ><?php echo Miniflux\Helper\escape($item['title']) ?></a>
         <?php endif ?>
         </span>
     </h2>
@@ -44,51 +44,51 @@
          <?php if ($menu !== 'feed-items'): ?>
         <li>
             <?php if (! isset($item['feed_title'])): ?>
-                <?= Miniflux\Helper\get_host_from_url($item['url']) ?>
+                <?php echo Miniflux\Helper\get_host_from_url($item['url']) ?>
             <?php else: ?>
-                <a href="?action=feed-items&amp;feed_id=<?= $item['feed_id'] ?>" title="<?= t('Show only this subscription') ?>"><?= Miniflux\Helper\escape($item['feed_title']) ?></a>
+                <a href="?action=feed-items&amp;feed_id=<?php echo $item['feed_id'] ?>" title="<?php echo t('Show only this subscription') ?>"><?php echo Miniflux\Helper\escape($item['feed_title']) ?></a>
             <?php endif ?>
         </li>
         <?php endif ?>
         <?php if (!empty($item['author'])): ?>
             <li>
-                <?= Miniflux\Helper\escape($item['author']) ?>
+                <?php echo Miniflux\Helper\escape($item['author']) ?>
             </li>
         <?php endif ?>
         <li class="hide-mobile">
-            <span title="<?= dt('%e %B %Y %k:%M', $item['updated']) ?>"><?= Miniflux\Helper\relative_time($item['updated']) ?></span>
+            <span title="<?php echo dt('%e %B %Y %k:%M', $item['updated']) ?>"><?php echo Miniflux\Helper\relative_time($item['updated']) ?></span>
         </li>
         <?php if ($display_mode === 'full' || $item_title_link == 'original'): ?>
             <li>
                 <a
-                    href="?action=show&amp;menu=<?= $menu ?><?= isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item['id'] ?>"
+                    href="?action=show&amp;menu=<?php echo $menu ?><?php echo isset($group_id) ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item['id'] ?>"
                     class="show"
-                ><?= t('view') ?></a>
+                ><?php echo t('view') ?></a>
             </li>
         <?php else: ?>
             <li class="hide-mobile">
-                <a href="<?= $item['url'] ?>" class="original" rel="noreferrer" target="_blank" <?= ($original_marks_read) ? 'data-action="mark-read"' : '' ?>><?= t('original link') ?></a>
+                <a href="<?php echo $item['url'] ?>" class="original" rel="noreferrer" target="_blank" <?php echo ($original_marks_read) ? 'data-action="mark-read"' : '' ?>><?php echo t('original link') ?></a>
             </li>
         <?php endif ?>
         <?php if ($item['enclosure']): ?>
             <li>
             <?php if (strpos($item['enclosure_type'], 'video/') === 0): ?>
-                <a href="<?= $item['enclosure'] ?>" class="video-enclosure" rel="noreferrer" target="_blank"><?= t('attachment') ?></a>
+                <a href="<?php echo $item['enclosure'] ?>" class="video-enclosure" rel="noreferrer" target="_blank"><?php echo t('attachment') ?></a>
             <?php elseif(strpos($item['enclosure_type'], 'audio/') === 0): ?>
-                <a href="<?= $item['enclosure'] ?>" class="audio-enclosure" rel="noreferrer" target="_blank"><?= t('attachment') ?></a>
+                <a href="<?php echo $item['enclosure'] ?>" class="audio-enclosure" rel="noreferrer" target="_blank"><?php echo t('attachment') ?></a>
             <?php elseif(strpos($item['enclosure_type'], 'image/') === 0): ?>
-                <a href="<?= $item['enclosure'] ?>" class="image-enclosure" rel="noreferrer" target="_blank"><?= t('attachment') ?></a>
+                <a href="<?php echo $item['enclosure'] ?>" class="image-enclosure" rel="noreferrer" target="_blank"><?php echo t('attachment') ?></a>
             <?php else: ?>
-                <a href="<?= $item['enclosure'] ?>" class="enclosure" rel="noreferrer" target="_blank"><?= t('attachment') ?></a>
+                <a href="<?php echo $item['enclosure'] ?>" class="enclosure" rel="noreferrer" target="_blank"><?php echo t('attachment') ?></a>
             <?php endif ?>
             </li>
         <?php endif ?>
-        <?= Miniflux\Template\load('bookmark_links', array('item' => $item, 'menu' => $menu, 'offset' => $offset)) ?>
-        <?= Miniflux\Template\load('status_links', array('item' => $item, 'menu' => $menu, 'offset' => $offset)) ?>
+        <?php echo Miniflux\Template\load('bookmark_links', array('item' => $item, 'menu' => $menu, 'offset' => $offset)) ?>
+        <?php echo Miniflux\Template\load('status_links', array('item' => $item, 'menu' => $menu, 'offset' => $offset)) ?>
     </ul>
     <?php if ($display_mode === 'full'): ?>
-        <div class="preview-full-content" <?= Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?= $item['content'] ?></div>
+        <div class="preview-full-content" <?php echo Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?php echo $item['content'] ?></div>
     <?php else: ?>
-        <p class="preview" <?= Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?= Miniflux\Helper\escape(Miniflux\Helper\summary(strip_tags($item['content']), 50, 300)) ?></p>
+        <p class="preview" <?php echo Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?php echo Miniflux\Helper\escape(Miniflux\Helper\summary(strip_tags($item['content']), 50, 300)) ?></p>
     <?php endif ?>
 </article>

--- a/app/templates/item.php
+++ b/app/templates/item.php
@@ -88,7 +88,9 @@
     </ul>
     <?php if ($display_mode === 'full'): ?>
         <div class="preview-full-content" <?php echo Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?php echo $item['content'] ?></div>
-    <?php else: ?>
+    <?php elseif ($display_mode === 'summaries'): ?>
         <p class="preview" <?php echo Miniflux\Helper\is_rtl($item) ? 'dir="rtl"' : 'dir="ltr"' ?>><?php echo Miniflux\Helper\escape(Miniflux\Helper\summary(strip_tags($item['content']), 50, 300)) ?></p>
+    <?php else: ?>
+        <p class="no-preview"></p>
     <?php endif ?>
 </article>

--- a/app/templates/keyboard_shortcuts.php
+++ b/app/templates/keyboard_shortcuts.php
@@ -1,23 +1,23 @@
 <div class="panel panel-default" id="shortcuts">
-    <h3><?= t('Keyboard shortcuts') ?></h3>
+    <h3><?php echo t('Keyboard shortcuts') ?></h3>
     <ul>
-        <li><?= t('Go to unread') ?> = <strong>gu</strong></li>
-        <li><?= t('Go to bookmarks') ?> = <strong>gb</strong></li>
-        <li><?= t('Go to history') ?> = <strong>gh</strong></li>
-        <li><?= t('Go to subscriptions') ?> = <strong>gs</strong></li>
-        <li><?= t('Go to preferences') ?> = <strong>gp</strong></li>
-        <li><?= t('Update all subscriptions') ?> = <strong>r</strong></li>
-        <li><?= t('Download content') ?> = <strong>d</strong></li>
-        <li><?= t('Previous item') ?> = <strong>p</strong> <?= t('or') ?> <strong>j</strong> <?= t('or') ?> <strong>&#9668;</strong></li>
-        <li><?= t('Next item') ?> = <strong>n</strong> <?= t('or') ?> <strong>k</strong> <?= t('or') ?> <strong>&#9658;</strong></li>
-        <li><?= t('Mark as read or unread') ?> = <strong>m</strong></li>
-        <li><?= t('Open original link') ?> = <strong>v</strong></li>
-        <li><?= t('Open item') ?> = <strong>o</strong></li>
-        <li><?= t('Bookmark item') ?> = <strong>f</strong></li>
-        <li><?= t('Previous page') ?> = <strong>h</strong></li>
-        <li><?= t('Next page') ?> = <strong>l</strong></li>
-        <li><?= t('Toggle RTL mode') ?> = <strong>z</strong></li>
-        <li><?= t('Show help') ?> = <strong>?</strong></li>
-        <li><?= t('Close help') ?> = <strong>q</strong></li>
+        <li><?php echo t('Go to unread') ?> = <strong>gu</strong></li>
+        <li><?php echo t('Go to bookmarks') ?> = <strong>gb</strong></li>
+        <li><?php echo t('Go to history') ?> = <strong>gh</strong></li>
+        <li><?php echo t('Go to subscriptions') ?> = <strong>gs</strong></li>
+        <li><?php echo t('Go to preferences') ?> = <strong>gp</strong></li>
+        <li><?php echo t('Update all subscriptions') ?> = <strong>r</strong></li>
+        <li><?php echo t('Download content') ?> = <strong>d</strong></li>
+        <li><?php echo t('Previous item') ?> = <strong>p</strong> <?php echo t('or') ?> <strong>j</strong> <?php echo t('or') ?> <strong>&#9668;</strong></li>
+        <li><?php echo t('Next item') ?> = <strong>n</strong> <?php echo t('or') ?> <strong>k</strong> <?php echo t('or') ?> <strong>&#9658;</strong></li>
+        <li><?php echo t('Mark as read or unread') ?> = <strong>m</strong></li>
+        <li><?php echo t('Open original link') ?> = <strong>v</strong></li>
+        <li><?php echo t('Open item') ?> = <strong>o</strong></li>
+        <li><?php echo t('Bookmark item') ?> = <strong>f</strong></li>
+        <li><?php echo t('Previous page') ?> = <strong>h</strong></li>
+        <li><?php echo t('Next page') ?> = <strong>l</strong></li>
+        <li><?php echo t('Toggle RTL mode') ?> = <strong>z</strong></li>
+        <li><?php echo t('Show help') ?> = <strong>?</strong></li>
+        <li><?php echo t('Close help') ?> = <strong>q</strong></li>
     </ul>
 </div>

--- a/app/templates/layout.php
+++ b/app/templates/layout.php
@@ -12,7 +12,7 @@
         <meta name="referrer" content="no-referrer">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-        <title><?= isset($title) ? Miniflux\Helper\escape($title) : t('Miniflux') ?></title>
+        <title><?php echo isset($title) ? Miniflux\Helper\escape($title) : t('Miniflux') ?></title>
 
         <link rel="icon" type="image/png" href="assets/img/favicon.png">
         <link rel="shortcut icon" href="favicon.ico">
@@ -21,43 +21,43 @@
         <link rel="apple-touch-icon" sizes="114x114" href="assets/img/touch-icon-iphone-retina.png">
         <link rel="apple-touch-icon" sizes="144x144" href="assets/img/touch-icon-ipad-retina.png">
 
-        <link href="<?= Miniflux\Helper\css() ?>" rel="stylesheet" media="screen">
-        <script type="text/javascript" src="assets/js/all.js?<?= filemtime('assets/js/all.js') ?>" defer></script>
+        <link href="<?php echo Miniflux\Helper\css() ?>" rel="stylesheet" media="screen">
+        <script type="text/javascript" src="assets/js/all.js?<?php echo filemtime('assets/js/all.js') ?>" defer></script>
     </head>
     <body>
         <header>
             <nav>
-                <a class="logo" href="?"><?= tne('mini%sflux%s','<span>','</span>') ?></a>
+                <a class="logo" href="?"><?php echo tne('mini%sflux%s','<span>','</span>') ?></a>
                 <ul>
-                    <li <?= isset($menu) && $menu === 'unread' ? 'class="active"' : '' ?>>
-                        <a href="?action=unread"><?= t('unread') ?><span id="nav-counter"><?= empty($nb_unread_items) ? '' : $nb_unread_items ?></span></a>
+                    <li <?php echo isset($menu) && $menu === 'unread' ? 'class="active"' : '' ?>>
+                        <a href="?action=unread"><?php echo t('unread') ?><span id="nav-counter"><?php echo empty($nb_unread_items) ? '' : $nb_unread_items ?></span></a>
                     </li>
-                    <li class="<?= isset($menu) && $menu === 'bookmarks' ? 'active hide-mobile' : 'hide-mobile' ?>">
-                        <a href="?action=bookmarks"><?= t('bookmarks') ?></a>
+                    <li class="<?php echo isset($menu) && $menu === 'bookmarks' ? 'active hide-mobile' : 'hide-mobile' ?>">
+                        <a href="?action=bookmarks"><?php echo t('bookmarks') ?></a>
                     </li>
-                    <li class="<?= isset($menu) && $menu === 'history' ? 'active hide-mobile' : 'hide-mobile' ?>">
-                        <a href="?action=history"><?= t('history') ?></a>
+                    <li class="<?php echo isset($menu) && $menu === 'history' ? 'active hide-mobile' : 'hide-mobile' ?>">
+                        <a href="?action=history"><?php echo t('history') ?></a>
                     </li>
-                    <li class="<?= isset($menu) && $menu === 'feeds' ? 'active hide-mobile' : 'hide-mobile' ?>">
-                        <a href="?action=feeds"><?= t('subscriptions') ?></a>
+                    <li class="<?php echo isset($menu) && $menu === 'feeds' ? 'active hide-mobile' : 'hide-mobile' ?>">
+                        <a href="?action=feeds"><?php echo t('subscriptions') ?></a>
                     </li>
-                    <li class="<?= isset($menu) && $menu === 'config' ? 'active hide-mobile' : 'hide-mobile' ?>">
-                        <a href="?action=config"><?= t('preferences') ?></a>
+                    <li class="<?php echo isset($menu) && $menu === 'config' ? 'active hide-mobile' : 'hide-mobile' ?>">
+                        <a href="?action=config"><?php echo t('preferences') ?></a>
                     </li>
                     <li class="hide-mobile">
-                        <a href="?action=logout"><?= t('logout') ?></a>
+                        <a href="?action=logout"><?php echo t('logout') ?></a>
                     </li>
-                    <li class="<?= isset($menu) && $menu === 'more' ? 'active hide-desktop' : 'hide-desktop' ?>">
-                        <a href="?action=more">∨ <?= t('menu') ?></a>
+                    <li class="<?php echo isset($menu) && $menu === 'more' ? 'active hide-desktop' : 'hide-desktop' ?>">
+                        <a href="?action=more">∨ <?php echo t('menu') ?></a>
                     </li>
                 </ul>
             </nav>
         </header>
-        <section class="page" data-item-page="<?= $menu ?>">
-            <?= Miniflux\Helper\flash('flash_message', '<div class="alert alert-success">%s</div>') ?>
-            <?= Miniflux\Helper\flash('flash_error_message', '<div class="alert alert-error">%s</div>') ?>
-            <?= $content_for_layout ?>
+        <section class="page" data-item-page="<?php echo $menu ?>">
+            <?php echo Miniflux\Helper\flash('flash_message', '<div class="alert alert-success">%s</div>') ?>
+            <?php echo Miniflux\Helper\flash('flash_error_message', '<div class="alert alert-error">%s</div>') ?>
+            <?php echo $content_for_layout ?>
         </section>
-        <?= Miniflux\Template\load('help_layer') ?>
+        <?php echo Miniflux\Template\load('help_layer') ?>
     </body>
 </html>

--- a/app/templates/login.php
+++ b/app/templates/login.php
@@ -19,38 +19,38 @@
         <link rel="apple-touch-icon" sizes="114x114" href="assets/img/touch-icon-iphone-retina.png">
         <link rel="apple-touch-icon" sizes="144x144" href="assets/img/touch-icon-ipad-retina.png">
         <title>Miniflux</title>
-        <link href="<?= Miniflux\Helper\css() ?>" rel="stylesheet" media="screen">
+        <link href="<?php echo Miniflux\Helper\css() ?>" rel="stylesheet" media="screen">
     </head>
     <body id="login-page">
         <section class="page" id="login">
             <?php if (isset($errors['login'])): ?>
-                <p class="alert alert-error"><?= Miniflux\Helper\escape($errors['login']) ?></p>
+                <p class="alert alert-error"><?php echo Miniflux\Helper\escape($errors['login']) ?></p>
             <?php endif ?>
 
             <form method="post" action="?action=login">
 
-                <?= Miniflux\Helper\form_hidden('csrf', $values) ?>
+                <?php echo Miniflux\Helper\form_hidden('csrf', $values) ?>
 
-                <?= Miniflux\Helper\form_label(t('Username'), 'username') ?>
-                <?= Miniflux\Helper\form_text('username', $values, $errors, array('autofocus', 'required')) ?><br/>
+                <?php echo Miniflux\Helper\form_label(t('Username'), 'username') ?>
+                <?php echo Miniflux\Helper\form_text('username', $values, $errors, array('autofocus', 'required')) ?><br/>
 
-                <?= Miniflux\Helper\form_label(t('Password'), 'password') ?>
-                <?= Miniflux\Helper\form_password('password', $values, $errors, array('required')) ?>
+                <?php echo Miniflux\Helper\form_label(t('Password'), 'password') ?>
+                <?php echo Miniflux\Helper\form_password('password', $values, $errors, array('required')) ?>
 
-                <?= Miniflux\Helper\form_checkbox('remember_me', t('Remember Me'), 1) ?><br/>
+                <?php echo Miniflux\Helper\form_checkbox('remember_me', t('Remember Me'), 1) ?><br/>
 
                 <?php if (ENABLE_MULTIPLE_DB && count($databases) > 1): ?>
                 <div id="database-selector">
-                    <h4><?= t('Select another database') ?></h4>
+                    <h4><?php echo t('Select another database') ?></h4>
                     <?php foreach ($databases as $filename => $dbname): ?>
-                        <?= Miniflux\Helper\form_radio('database', $dbname, $filename, ($current_database === $filename)) ?>
+                        <?php echo Miniflux\Helper\form_radio('database', $dbname, $filename, ($current_database === $filename)) ?>
                     <?php endforeach ?>
                 </div>
                 <?php endif ?>
 
 
                 <div class="form-actions">
-                    <input type="submit" value="<?= t('Sign in') ?>" class="btn btn-blue"/>
+                    <input type="submit" value="<?php echo t('Sign in') ?>" class="btn btn-blue"/>
                 </div>
             </form>
 

--- a/app/templates/new_db.php
+++ b/app/templates/new_db.php
@@ -1,36 +1,36 @@
 <div class="page-header">
-    <h2><?= t('New database') ?></h2>
+    <h2><?php echo t('New database') ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li class="active"><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li class="active"><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
 
 <form method="post" action="?action=new-db" autocomplete="off">
 
-    <?= Miniflux\Helper\form_hidden('csrf', $values) ?>
+    <?php echo Miniflux\Helper\form_hidden('csrf', $values) ?>
 
-    <?= Miniflux\Helper\form_label(t('Database name'), 'name') ?>
-    <?= Miniflux\Helper\form_text('name', $values, $errors, array('required', 'autofocus')) ?>
-    <p class="form-help"><?= t('The name must have only alpha-numeric characters') ?></p>
+    <?php echo Miniflux\Helper\form_label(t('Database name'), 'name') ?>
+    <?php echo Miniflux\Helper\form_text('name', $values, $errors, array('required', 'autofocus')) ?>
+    <p class="form-help"><?php echo t('The name must have only alpha-numeric characters') ?></p>
 
-    <?= Miniflux\Helper\form_label(t('Username'), 'username') ?>
-    <?= Miniflux\Helper\form_text('username', $values, $errors, array('required')) ?><br/>
+    <?php echo Miniflux\Helper\form_label(t('Username'), 'username') ?>
+    <?php echo Miniflux\Helper\form_text('username', $values, $errors, array('required')) ?><br/>
 
-    <?= Miniflux\Helper\form_label(t('Password'), 'password') ?>
-    <?= Miniflux\Helper\form_password('password', $values, $errors, array('required')) ?>
+    <?php echo Miniflux\Helper\form_label(t('Password'), 'password') ?>
+    <?php echo Miniflux\Helper\form_password('password', $values, $errors, array('required')) ?>
 
-    <?= Miniflux\Helper\form_label(t('Confirmation'), 'confirmation') ?>
-    <?= Miniflux\Helper\form_password('confirmation', $values, $errors, array('required')) ?><br/>
+    <?php echo Miniflux\Helper\form_label(t('Confirmation'), 'confirmation') ?>
+    <?php echo Miniflux\Helper\form_password('confirmation', $values, $errors, array('required')) ?><br/>
 
     <div class="form-actions">
-        <button type="submit" class="btn btn-blue"><?= t('Create') ?></button>
-        <?= t('or') ?> <a href="?action=config"><?= t('cancel') ?></a>
+        <button type="submit" class="btn btn-blue"><?php echo t('Create') ?></button>
+        <?php echo t('or') ?> <a href="?action=config"><?php echo t('cancel') ?></a>
     </div>
 </form>

--- a/app/templates/paging.php
+++ b/app/templates/paging.php
@@ -22,10 +22,10 @@
 ?>
 <div id="items-paging">
 <?php if ($offset > 0): ?>
-    <a id="previous-page" href="?action=<?= $menu ?>&amp;offset=<?= ($offset - $items_per_page) ?><?= $optionals; ?>">« <?= t('Previous page') ?></a>
+    <a id="previous-page" href="?action=<?php echo $menu ?>&amp;offset=<?php echo ($offset - $items_per_page) ?><?php echo $optionals; ?>">« <?php echo t('Previous page') ?></a>
 <?php endif ?>
 &nbsp;
 <?php if (($nb_items - $offset) > $items_per_page): ?>
-    <a id="next-page" href="?action=<?= $menu ?>&amp;offset=<?= ($offset + $items_per_page) ?><?= $optionals; ?>"><?= t('Next page') ?> »</a>
+    <a id="next-page" href="?action=<?php echo $menu ?>&amp;offset=<?php echo ($offset + $items_per_page) ?><?php echo $optionals; ?>"><?php echo t('Next page') ?> »</a>
 <?php endif ?>
 </div>

--- a/app/templates/search.php
+++ b/app/templates/search.php
@@ -1,14 +1,14 @@
-<?= Miniflux\Template\load('search_form', array('text' => $text, 'opened' => true)) ?>
+<?php echo Miniflux\Template\load('search_form', array('text' => $text, 'opened' => true)) ?>
 <?php if (empty($items)): ?>
-    <p class="alert alert-info"><?= t('There are no results for your search') ?></p>
+    <p class="alert alert-info"><?php echo t('There are no results for your search') ?></p>
 <?php else: ?>
     <div class="page-header">
-        <h2><?= t('Search') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <h2><?php echo t('Search') ?><span id="page-counter"><?php echo isset($nb_items) ? $nb_items : '' ?></span></h2>
     </div>
 
     <section class="items" id="listing">
         <?php foreach ($items as $item): ?>
-            <?= Miniflux\Template\load('item', array(
+            <?php echo Miniflux\Template\load('item', array(
                 'item' => $item,
                 'menu' => $menu,
                 'offset' => $offset,
@@ -20,7 +20,7 @@
             )) ?>
         <?php endforeach ?>
 
-        <?= Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'text' => $text)) ?>
+        <?php echo Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'text' => $text)) ?>
     </section>
 
 <?php endif ?>

--- a/app/templates/search_form.php
+++ b/app/templates/search_form.php
@@ -1,7 +1,7 @@
 <div class="search">
-    <span id="search-opener"<?= isset($opened) && $opened ? ' class="hide"' : '' ?> data-action="show-search">&laquo; <?= t('Search')?></span>
-    <form id="search-form"<?= isset($opened) && $opened ? '' : ' class="hide"' ?> action="?" method="get">
-        <?= Miniflux\Helper\form_hidden('action', array('action' => 'search')) ?>
-        <?= Miniflux\Helper\form_text('text', array('text' => isset($text) ? $text : ''), array(), array('required', 'placeholder="' . t('Search') . '"')) ?>
+    <span id="search-opener"<?php echo isset($opened) && $opened ? ' class="hide"' : '' ?> data-action="show-search">&laquo; <?php echo t('Search')?></span>
+    <form id="search-form"<?php echo isset($opened) && $opened ? '' : ' class="hide"' ?> action="?" method="get">
+        <?php echo Miniflux\Helper\form_hidden('action', array('action' => 'search')) ?>
+        <?php echo Miniflux\Helper\form_text('text', array('text' => isset($text) ? $text : ''), array(), array('required', 'placeholder="' . t('Search') . '"')) ?>
     </form>
 </div>

--- a/app/templates/services.php
+++ b/app/templates/services.php
@@ -1,13 +1,13 @@
 <div class="page-header">
-    <h2><?= $title ?></h2>
+    <h2><?php echo $title ?></h2>
     <nav>
         <ul>
-            <li><a href="?action=config"><?= t('general') ?></a></li>
-            <li class="active"><a href="?action=services"><?= t('external services') ?></a></li>
-            <li><a href="?action=api"><?= t('api') ?></a></li>
-            <li><a href="?action=database"><?= t('database') ?></a></li>
-            <li><a href="?action=help"><?= t('help') ?></a></li>
-            <li><a href="?action=about"><?= t('about') ?></a></li>
+            <li><a href="?action=config"><?php echo t('general') ?></a></li>
+            <li class="active"><a href="?action=services"><?php echo t('external services') ?></a></li>
+            <li><a href="?action=api"><?php echo t('api') ?></a></li>
+            <li><a href="?action=database"><?php echo t('database') ?></a></li>
+            <li><a href="?action=help"><?php echo t('help') ?></a></li>
+            <li><a href="?action=about"><?php echo t('about') ?></a></li>
         </ul>
     </nav>
 </div>
@@ -15,33 +15,33 @@
 
 <form method="post" action="?action=services" autocomplete="off" id="config-form">
 
-    <?= Miniflux\Helper\form_hidden('csrf', $values) ?>
+    <?php echo Miniflux\Helper\form_hidden('csrf', $values) ?>
     
-    <h3><?= t('Pinboard') ?></h3>
+    <h3><?php echo t('Pinboard') ?></h3>
     <div class="options">
-        <?= Miniflux\Helper\form_checkbox('pinboard_enabled', t('Send bookmarks to Pinboard'), 1, isset($values['pinboard_enabled']) && $values['pinboard_enabled'] == 1) ?><br />
+        <?php echo Miniflux\Helper\form_checkbox('pinboard_enabled', t('Send bookmarks to Pinboard'), 1, isset($values['pinboard_enabled']) && $values['pinboard_enabled'] == 1) ?><br />
 
-        <?= Miniflux\Helper\form_label(t('Pinboard API token'), 'pinboard_token') ?>
-        <?= Miniflux\Helper\form_text('pinboard_token', $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Pinboard API token'), 'pinboard_token') ?>
+        <?php echo Miniflux\Helper\form_text('pinboard_token', $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Pinboard tags'), 'pinboard_tags') ?>
-        <?= Miniflux\Helper\form_text('pinboard_tags', $values, $errors) ?>
+        <?php echo Miniflux\Helper\form_label(t('Pinboard tags'), 'pinboard_tags') ?>
+        <?php echo Miniflux\Helper\form_text('pinboard_tags', $values, $errors) ?>
     </div>
 
 
-    <h3><?= t('Instapaper') ?></h3>
+    <h3><?php echo t('Instapaper') ?></h3>
     <div class="options">
-        <?= Miniflux\Helper\form_checkbox('instapaper_enabled', t('Send bookmarks to Instapaper'), 1, isset($values['instapaper_enabled']) && $values['instapaper_enabled'] == 1) ?><br />
+        <?php echo Miniflux\Helper\form_checkbox('instapaper_enabled', t('Send bookmarks to Instapaper'), 1, isset($values['instapaper_enabled']) && $values['instapaper_enabled'] == 1) ?><br />
 
-        <?= Miniflux\Helper\form_label(t('Instapaper username'), 'instapaper_username') ?>
-        <?= Miniflux\Helper\form_text('instapaper_username', $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Instapaper username'), 'instapaper_username') ?>
+        <?php echo Miniflux\Helper\form_text('instapaper_username', $values, $errors) ?><br/>
 
-        <?= Miniflux\Helper\form_label(t('Instapaper password'), 'instapaper_password') ?>
-        <?= Miniflux\Helper\form_password('instapaper_password', $values, $errors) ?><br/>
+        <?php echo Miniflux\Helper\form_label(t('Instapaper password'), 'instapaper_password') ?>
+        <?php echo Miniflux\Helper\form_password('instapaper_password', $values, $errors) ?><br/>
     </div>
     
     <div class="form-actions">
-        <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
+        <input type="submit" value="<?php echo t('Save') ?>" class="btn btn-blue"/>
     </div>
 </form>
 </section>

--- a/app/templates/show_item.php
+++ b/app/templates/show_item.php
@@ -1,119 +1,119 @@
 <?php if (empty($item)): ?>
-    <p class="alert alert-error"><?= t('Item not found') ?></p>
+    <p class="alert alert-error"><?php echo t('Item not found') ?></p>
 <?php else: ?>
     <article
         class="item"
         id="current-item"
-        data-item-id="<?= $item['id'] ?>"
-        data-item-status="<?= $item['status'] ?>"
-        data-item-bookmark="<?= $item['bookmark'] ?>"
+        data-item-id="<?php echo $item['id'] ?>"
+        data-item-status="<?php echo $item['status'] ?>"
+        data-item-bookmark="<?php echo $item['bookmark'] ?>"
     >
 
         <?php if (isset($item_nav)): ?>
         <nav class="top">
             <span class="nav-left">
                 <?php if ($item_nav['previous']): ?>
-                    <a href="?action=show&amp;menu=<?= $menu ?><?= $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item_nav['previous']['id'] ?>" id="previous-item" title="<?= Miniflux\Helper\escape($item_nav['previous']['title']) ?>"><?= t('Previous') ?></a>
+                    <a href="?action=show&amp;menu=<?php echo $menu ?><?php echo $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item_nav['previous']['id'] ?>" id="previous-item" title="<?php echo Miniflux\Helper\escape($item_nav['previous']['title']) ?>"><?php echo t('Previous') ?></a>
                 <?php else: ?>
-                    <?= t('Previous') ?>
+                    <?php echo t('Previous') ?>
                 <?php endif ?>
             </span>
 
             <span class="nav-right">
                 <?php if ($item_nav['next']): ?>
-                    <a href="?action=show&amp;menu=<?= $menu ?><?= $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item_nav['next']['id'] ?>" id="next-item" title="<?= Miniflux\Helper\escape($item_nav['next']['title']) ?>"><?= t('Next') ?></a>
+                    <a href="?action=show&amp;menu=<?php echo $menu ?><?php echo $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item_nav['next']['id'] ?>" id="next-item" title="<?php echo Miniflux\Helper\escape($item_nav['next']['title']) ?>"><?php echo t('Next') ?></a>
                 <?php else: ?>
-                    <?= t('Next') ?>
+                    <?php echo t('Next') ?>
                 <?php endif ?>
             </span>
         </nav>
         <?php endif ?>
 
-        <h1 <?= Miniflux\Helper\is_rtl($item + array('rtl' => $feed['rtl'])) ? 'dir="rtl"' : 'dir="ltr"' ?>>
-            <a href="<?= $item['url'] ?>" rel="noreferrer" target="_blank" class="original"><?= Miniflux\Helper\escape($item['title']) ?></a>
+        <h1 <?php echo Miniflux\Helper\is_rtl($item + array('rtl' => $feed['rtl'])) ? 'dir="rtl"' : 'dir="ltr"' ?>>
+            <a href="<?php echo $item['url'] ?>" rel="noreferrer" target="_blank" class="original"><?php echo Miniflux\Helper\escape($item['title']) ?></a>
         </h1>
 
         <ul class="item-infos">
             <li>
                 <a
                     class="bookmark-icon"
-                    href="?action=bookmark&amp;value=<?= (int)!$item['bookmark'] ?>&amp;id=<?= $item['id'] ?>&amp;redirect=show&amp;menu=<?= $menu ?>"
-                    title="<?= ($item['bookmark']) ? t('remove bookmark') : t('bookmark') ?>"
-                    data-reverse-title="<?= ($item['bookmark']) ? t('bookmark') :t('remove bookmark') ?>"
+                    href="?action=bookmark&amp;value=<?php echo (int)!$item['bookmark'] ?>&amp;id=<?php echo $item['id'] ?>&amp;redirect=show&amp;menu=<?php echo $menu ?>"
+                    title="<?php echo ($item['bookmark']) ? t('remove bookmark') : t('bookmark') ?>"
+                    data-reverse-title="<?php echo ($item['bookmark']) ? t('bookmark') :t('remove bookmark') ?>"
                     data-action="bookmark"
                 ></a>
             </li>
             <li>
-                <a href="?action=feed-items&amp;feed_id=<?= $feed['id'] ?>"><?= Miniflux\Helper\escape($feed['title']) ?></a>
+                <a href="?action=feed-items&amp;feed_id=<?php echo $feed['id'] ?>"><?php echo Miniflux\Helper\escape($feed['title']) ?></a>
             </li>
             <?php if (!empty($item['author'])): ?>
                 <li>
-                    <?= Miniflux\Helper\escape($item['author']) ?>
+                    <?php echo Miniflux\Helper\escape($item['author']) ?>
                 </li>
             <?php endif ?>
             <li class="hide-mobile">
-                <span title="<?= dt('%e %B %Y %k:%M', $item['updated']) ?>"><?= Miniflux\Helper\relative_time($item['updated']) ?></span>
+                <span title="<?php echo dt('%e %B %Y %k:%M', $item['updated']) ?>"><?php echo Miniflux\Helper\relative_time($item['updated']) ?></span>
             </li>
             <?php if ($item['enclosure']): ?>
             <li>
-                <a href="<?= $item['enclosure'] ?>" rel="noreferrer" target="_blank"><?= t('attachment') ?></a>
+                <a href="<?php echo $item['enclosure'] ?>" rel="noreferrer" target="_blank"><?php echo t('attachment') ?></a>
             </li>
             <?php endif ?>
             <li class="hide-mobile">
                 <span id="download-item"
-                      data-failure-message="<?= t('unable to fetch content') ?>"
-                      data-before-message="<?= t('in progress...') ?>"
-                      data-after-message="<?= t('content downloaded') ?>">
-                    <a href="#" data-action="download-item"><?= t('download content') ?></a>
+                      data-failure-message="<?php echo t('unable to fetch content') ?>"
+                      data-before-message="<?php echo t('in progress...') ?>"
+                      data-after-message="<?php echo t('content downloaded') ?>">
+                    <a href="#" data-action="download-item"><?php echo t('download content') ?></a>
                 </span>
             </li>
             <?php if ($group_id): ?>
             <li>
-                <a href="?action=unread&amp;group_id=<?= $group_id ?>"><?= t('Back to the group') ?></a>
+                <a href="?action=unread&amp;group_id=<?php echo $group_id ?>"><?php echo t('Back to the group') ?></a>
             </li>
             <?php endif; ?>
         </ul>
 
-        <div id="item-content" <?= Miniflux\Helper\is_rtl($item + array('rtl' => $feed['rtl']))  ? 'dir="rtl"' : 'dir="ltr"' ?>>
+        <div id="item-content" <?php echo Miniflux\Helper\is_rtl($item + array('rtl' => $feed['rtl']))  ? 'dir="rtl"' : 'dir="ltr"' ?>>
 
             <?php if ($item['enclosure']): ?>
                 <?php if (strpos($item['enclosure_type'], 'audio') !== false): ?>
                 <div id="item-content-enclosure">
                     <audio controls>
-                        <source src="<?= $item['enclosure'] ?>" type="<?= $item['enclosure_type'] ?>">
+                        <source src="<?php echo $item['enclosure'] ?>" type="<?php echo $item['enclosure_type'] ?>">
                     </audio>
                 </div>
                 <?php elseif (strpos($item['enclosure_type'], 'video') !== false): ?>
                 <div id="item-content-enclosure">
                     <video controls>
-                        <source src="<?= $item['enclosure'] ?>" type="<?= $item['enclosure_type'] ?>">
+                        <source src="<?php echo $item['enclosure'] ?>" type="<?php echo $item['enclosure_type'] ?>">
                     </video>
                 </div>
                 <?php elseif (strpos($item['enclosure_type'], 'image') !== false && $item['content'] === ''): ?>
                 <div id="item-content-enclosure">
-                    <img src="<?= $item['enclosure'] ?>" alt="enclosure"/>
+                    <img src="<?php echo $item['enclosure'] ?>" alt="enclosure"/>
                 </div>
                 <?php endif ?>
             <?php endif ?>
 
-            <?= $item['content'] ?>
+            <?php echo $item['content'] ?>
         </div>
 
         <?php if (isset($item_nav)): ?>
         <nav class="bottom">
             <span class="nav-left">
                 <?php if ($item_nav['previous']): ?>
-                    <a href="?action=show&amp;menu=<?= $menu ?><?= $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item_nav['previous']['id'] ?>" id="previous-item" title="<?= Miniflux\Helper\escape($item_nav['previous']['title']) ?>"><?= t('Previous') ?></a>
+                    <a href="?action=show&amp;menu=<?php echo $menu ?><?php echo $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item_nav['previous']['id'] ?>" id="previous-item" title="<?php echo Miniflux\Helper\escape($item_nav['previous']['title']) ?>"><?php echo t('Previous') ?></a>
                 <?php else: ?>
-                    <?= t('Previous') ?>
+                    <?php echo t('Previous') ?>
                 <?php endif ?>
             </span>
 
             <span class="nav-right">
                 <?php if ($item_nav['next']): ?>
-                    <a href="?action=show&amp;menu=<?= $menu ?><?= $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?= $item_nav['next']['id'] ?>" id="next-item" title="<?= Miniflux\Helper\escape($item_nav['next']['title']) ?>"><?= t('Next') ?></a>
+                    <a href="?action=show&amp;menu=<?php echo $menu ?><?php echo $group_id ? '&amp;group_id='.$group_id : '' ?>&amp;id=<?php echo $item_nav['next']['id'] ?>" id="next-item" title="<?php echo Miniflux\Helper\escape($item_nav['next']['title']) ?>"><?php echo t('Next') ?></a>
                 <?php else: ?>
-                    <?= t('Next') ?>
+                    <?php echo t('Next') ?>
                 <?php endif ?>
             </span>
         </nav>

--- a/app/templates/show_more.php
+++ b/app/templates/show_more.php
@@ -1,22 +1,22 @@
 <div class="menu-more">
 <ul>
     <li>
-        <a href="?action=unread"><?= t('unread') ?></a>
+        <a href="?action=unread"><?php echo t('unread') ?></a>
     </li>
     <li>
-        <a href="?action=bookmarks"><?= t('bookmarks') ?></a>
+        <a href="?action=bookmarks"><?php echo t('bookmarks') ?></a>
     </li>
     <li>
-        <a href="?action=history"><?= t('history') ?></a>
+        <a href="?action=history"><?php echo t('history') ?></a>
     </li>
     <li>
-        <a href="?action=feeds"><?= t('subscriptions') ?></a>
+        <a href="?action=feeds"><?php echo t('subscriptions') ?></a>
     </li>
     <li>
-        <a href="?action=config"><?= t('preferences') ?></a>
+        <a href="?action=config"><?php echo t('preferences') ?></a>
     </li>
     <li>
-        <a href="?action=logout"><?= t('logout') ?></a>
+        <a href="?action=logout"><?php echo t('logout') ?></a>
     </li>
 </ul>
 </div>

--- a/app/templates/status_links.php
+++ b/app/templates/status_links.php
@@ -1,24 +1,24 @@
 <li class="hide-mobile">
     <a
-        href="?action=mark-item-removed&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
+        href="?action=mark-item-removed&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
         data-action="mark-removed"
         class="delete"
-    ><?= t('remove') ?></a>
+    ><?php echo t('remove') ?></a>
 </li>
 <li class="hide-mobile">
     <?php if ($item['status'] == 'unread'): ?>
         <a
             class="mark"
-            href="?action=mark-item-read&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
+            href="?action=mark-item-read&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
             data-action="mark-read"
-            data-reverse-label="<?= t('mark as unread') ?>"
-        ><?= t('mark as read') ?></a>
+            data-reverse-label="<?php echo t('mark as unread') ?>"
+        ><?php echo t('mark as read') ?></a>
     <?php else: ?>
         <a
             class="mark"
-            href="?action=mark-item-unread&amp;id=<?= $item['id'] ?>&amp;offset=<?= $offset ?>&amp;redirect=<?= $menu ?>&amp;feed_id=<?= $item['feed_id'] ?>"
+            href="?action=mark-item-unread&amp;id=<?php echo $item['id'] ?>&amp;offset=<?php echo $offset ?>&amp;redirect=<?php echo $menu ?>&amp;feed_id=<?php echo $item['feed_id'] ?>"
             data-action="mark-unread"
-            data-reverse-label="<?= t('mark as read') ?>"
-        ><?= t('mark as unread') ?></a>
+            data-reverse-label="<?php echo t('mark as read') ?>"
+        ><?php echo t('mark as unread') ?></a>
     <?php endif ?>
 </li>

--- a/app/templates/unread_items.php
+++ b/app/templates/unread_items.php
@@ -1,13 +1,13 @@
 
-    <?= Miniflux\Template\load('search_form') ?>
+    <?php echo Miniflux\Template\load('search_form') ?>
     <div class="page-header">
-        <h2><?= t('Unread') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
+        <h2><?php echo t('Unread') ?><span id="page-counter"><?php echo isset($nb_items) ? $nb_items : '' ?></span></h2>
         <?php if (!empty($groups)): ?>
         <nav>
             <ul id="grouplist">
                 <?php foreach ($groups as $group): ?>
-                <li  <?= $group['id'] == $group_id ? 'class="active"' : '' ?>>
-                    <a href="?action=unread&group_id=<?=$group['id']?>"><?=$group['title']?></a>
+                <li  <?php echo $group['id'] == $group_id ? 'class="active"' : '' ?>>
+                    <a href="?action=unread&group_id=<?php echo$group['id']?>"><?php echo$group['title']?></a>
                 </li>
                 <?php endforeach ?>
             </ul>
@@ -16,20 +16,20 @@
 
         <ul>
             <li>
-                <a href="?action=unread<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
+                <a href="?action=unread<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?php echo $direction == 'asc' ? 'desc' : 'asc' ?>"><?php echo tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
             <li>
-                <a href="?action=mark-all-read<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-all-read<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?php echo t('mark all as read') ?></a>
             </li>
         </ul>
     </div>
 
     <section class="items" id="listing">
         <?php if (empty($items)): ?>
-            <p class="alert alert-info"><?= t('Nothing to read') ?></p>
+            <p class="alert alert-info"><?php echo t('Nothing to read') ?></p>
         <?php else: ?>
             <?php foreach ($items as $item): ?>
-                <?= Miniflux\Template\load('item', array(
+                <?php echo Miniflux\Template\load('item', array(
                     'item' => $item,
                     'menu' => $menu,
                     'offset' => $offset,
@@ -43,9 +43,9 @@
             <?php endforeach ?>
 
             <div id="bottom-menu">
-                <a href="?action=mark-all-read<?= $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-all-read<?php echo $group_id === null ? '' : '&amp;group_id='.$group_id ?>"><?php echo t('mark all as read') ?></a>
             </div>
 
-            <?= Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
+            <?php echo Miniflux\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
         <?php endif ?>
     </section>


### PR DESCRIPTION
Removed DirectoryIterator::getExtension usage (>=5.3.6)
Removed short_tag requirement
- Be sure that the unit tests pass  - OK (6 tests, 11 assertions)
- If you create a new feature, test your code, do not introduce new bugs - Runs fine on my prod system
- Avoid code duplication - Done
- Small pull-requests are easier to review and can be merged quickly - Eh, can't help the size ;)
- 1 pull-request == 1 feature/improvement - Yup 5.3.3 compat
