### PR TITLE
Open search field by pressing the '/' key

### DIFF
--- a/assets/js/all.js
+++ b/assets/js/all.js
@@ -713,6 +713,10 @@ Miniflux.Event = (function() {
                         case 63:
                             Miniflux.Nav.ShowHelp();
                             break;
+                        case '/':
+                        case 47:
+                            Miniflux.Nav.ShowSearch();
+                            break;
                         case 'Q':
                         case 81:  // Q
                         case 'q':

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -196,6 +196,10 @@ Miniflux.Event = (function() {
                         case 63:
                             Miniflux.Nav.ShowHelp();
                             break;
+                        case '/':
+                        case 47:
+                            Miniflux.Nav.ShowSearch();
+                            break;
                         case 'Q':
                         case 81:  // Q
                         case 'q':


### PR DESCRIPTION
The slash key is a well-known shortcut to open and focus the
search field in several web apps, e. g. DuckDuckGo or Google Plus.

Some editors and pagers use the same shortcut (Vim, less, ...).

This commit adds an event handler for the pressed `/` key which
calls the `ShowSearch()` function.