### PR TITLE
Refactoring the `js` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: docker-destroy
 .PHONY: docker-run
 .PHONY: archive
+.PHONY: js
 
 JS_FILE = assets/js/all.js
 CONTAINER = miniflux
@@ -21,11 +22,16 @@ docker-destroy:
 docker-run:
 	@ docker run --rm --name $(CONTAINER) -P $(IMAGE):$(TAG)
 
-js:
-	@ rm -f ${JS_FILE}
-	@ echo "/* AUTO GENERATED FILE, DO NOT MODIFY THIS FILE, USE 'make js' */" > ${JS_FILE}
-	@ cat assets/js/app.js assets/js/feed.js assets/js/item.js assets/js/event.js assets/js/nav.js >> ${JS_FILE}
-	@ echo "Miniflux.App.Run();" >> ${JS_FILE}
+js: $(JS_FILE)
+
+$(JS_FILE): assets/js/app.js \
+    assets/js/feed.js \
+    assets/js/item.js \
+    assets/js/event.js \
+    assets/js/nav.js
+	@ echo "/* AUTO GENERATED FILE, DO NOT MODIFY THIS FILE, USE 'make js' */" > $@
+	@ cat $^ >> $@
+	@ echo "Miniflux.App.Run();" >> $@
 
 # Build a new archive: make archive version=1.2.3 dst=/tmp
 archive:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+.PHONY: docker-image
+.PHONY: docker-push
+.PHONY: docker-destroy
+.PHONY: docker-run
+.PHONY: archive
+
 JS_FILE = assets/js/all.js
 CONTAINER = miniflux
 IMAGE = miniflux/miniflux


### PR DESCRIPTION
The JavaScript build target was rewritten into a more Make-like form with a real file target and prerequisites. 

The old target `js` is kept for backwards compatibility and declared as "phony".

In addition, the other targets were declared as "phony". By default, targets in Makefiles maps to files. This isn't the case here as the targets are used as simple "shortcuts". That kind of target should be declared as "phony", as described in the [Make manual](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html).