### PR TITLE
fix: listen to `keyup` instead of `keypress` for search field activation

### DIFF
--- a/assets/js/all.js
+++ b/assets/js/all.js
@@ -713,10 +713,6 @@ Miniflux.Event = (function() {
                         case 63:
                             Miniflux.Nav.ShowHelp();
                             break;
-                        case '/':
-                        case 47:
-                            Miniflux.Nav.ShowSearch();
-                            break;
                         case 'Q':
                         case 81:  // Q
                         case 'q':
@@ -749,6 +745,22 @@ Miniflux.Event = (function() {
                     case "Right":
                     case 39:
                         Miniflux.Nav.SelectNextItem();
+                        break;
+                }
+            };
+
+            document.onkeyup = function(e) {
+
+                if (isEventIgnored(e)) {
+                    return;
+                }
+
+                Miniflux.Event.lastEventType = "keyboard";
+
+                switch (e.key || e.which) {
+                    case '/':
+                    case 47:
+                        Miniflux.Nav.ShowSearch();
                         break;
                 }
             };

--- a/assets/js/event.js
+++ b/assets/js/event.js
@@ -196,10 +196,6 @@ Miniflux.Event = (function() {
                         case 63:
                             Miniflux.Nav.ShowHelp();
                             break;
-                        case '/':
-                        case 47:
-                            Miniflux.Nav.ShowSearch();
-                            break;
                         case 'Q':
                         case 81:  // Q
                         case 'q':
@@ -232,6 +228,22 @@ Miniflux.Event = (function() {
                     case "Right":
                     case 39:
                         Miniflux.Nav.SelectNextItem();
+                        break;
+                }
+            };
+
+            document.onkeyup = function(e) {
+
+                if (isEventIgnored(e)) {
+                    return;
+                }
+
+                Miniflux.Event.lastEventType = "keyboard";
+
+                switch (e.key || e.which) {
+                    case '/':
+                    case 47:
+                        Miniflux.Nav.ShowSearch();
                         break;
                 }
             };


### PR DESCRIPTION
The `/` character (keyboard shortcut for activating the search field) is entered into the search field after calling `Miniflux.Nav.ShowSearch()` from the `keypress` event handler. That's unexpected behaviour.

This commit fixes that by attaching the keyboard event handler to the `keyup` event.