### PR TITLE
Add support for MySQL Databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,8 @@ script:
   - ./vendor/bin/phpunit -c tests/phpunit.unit.postgres.xml
   - ./vendor/bin/phpunit -c tests/phpunit.unit.mysql.xml
   - ./vendor/bin/phpunit -c tests/phpunit.functional.sqlite.xml
-  - cp ./tests/ci/config.postgres.php $TRAVIS_BUILD_DIR/config.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/ApiTest.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/FeverApiTest.php
-  - cp ./tests/ci/config.mysql.php $TRAVIS_BUILD_DIR/config.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/ApiTest.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/FeverApiTest.php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,14 @@ script:
   - ./node_modules/.bin/jshint assets/js/src/*.js
   - ./vendor/bin/phpunit -c tests/phpunit.unit.sqlite.xml
   - ./vendor/bin/phpunit -c tests/phpunit.unit.postgres.xml
+  - ./vendor/bin/phpunit -c tests/phpunit.unit.mysql.xml
   - ./vendor/bin/phpunit -c tests/phpunit.functional.sqlite.xml
   - cp ./tests/ci/config.postgres.php $TRAVIS_BUILD_DIR/config.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/ApiTest.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/FeverApiTest.php
+  - cp ./tests/ci/config.mysql.php $TRAVIS_BUILD_DIR/config.php
+  - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/ApiTest.php
+  - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/FeverApiTest.php
 
 after_failure:
   - cat apache_error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ script:
   - ./vendor/bin/phpunit -c tests/phpunit.unit.postgres.xml
   - ./vendor/bin/phpunit -c tests/phpunit.unit.mysql.xml
   - ./vendor/bin/phpunit -c tests/phpunit.functional.sqlite.xml
+  - cp ./tests/ci/config.postgres.php $TRAVIS_BUILD_DIR/config.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/ApiTest.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.postgres.xml tests/functional/FeverApiTest.php
+  - cp ./tests/ci/config.mysql.php $TRAVIS_BUILD_DIR/config.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/ApiTest.php
   - ./vendor/bin/phpunit -c tests/phpunit.functional.mysql.xml tests/functional/FeverApiTest.php
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 .PHONY: js
 .PHONY: unit-test-sqlite
 .PHONY: unit-test-postgres
+.PHONY: unit-test-mysql
 .PHONY: sync-locales
 .PHONY: find-locales
 
@@ -58,6 +59,9 @@ unit-test-sqlite:
 
 unit-test-postgres:
 	@ ./vendor/bin/phpunit -c tests/phpunit.unit.postgres.xml
+
+unit-test-mysql:
+	@ ./vendor/bin/phpunit -c tests/phpunit.unit.mysql.xml
 
 sync-locales:
 	@ php scripts/sync-locales.php

--- a/app/check_setup.php
+++ b/app/check_setup.php
@@ -40,6 +40,10 @@ if (DB_DRIVER === 'postgres' && ! extension_loaded('pdo_pgsql')) {
     die('PHP extension required: pdo_pgsql');
 }
 
+if (DB_DRIVER === 'mysql' && ! extension_loaded('pdo_mysql')) {
+    die('PHP extension required: pdo_mysql');
+}
+
 // Check extension: mbstring (simpleValidator)
 if (! extension_loaded('mbstring')) {
     die('PHP extension required: mbstring');

--- a/app/core/database.php
+++ b/app/core/database.php
@@ -38,6 +38,16 @@ function get_connection_parameters()
             'database' => DB_NAME,
             'port'     => DB_PORT,
         );
+    } elseif (DB_DRIVER === 'mysql') {
+        require_once __DIR__.'/../schemas/mysql.php';
+        $params = array(
+            'driver'   => 'mysql',
+            'hostname' => DB_HOSTNAME,
+            'username' => DB_USERNAME,
+            'password' => DB_PASSWORD,
+            'database' => DB_NAME,
+            'port'     => DB_PORT,
+        );
     } else {
         require_once __DIR__.'/../schemas/sqlite.php';
         $params = array(

--- a/app/schemas/mysql.php
+++ b/app/schemas/mysql.php
@@ -19,7 +19,7 @@ function version_2(PDO $pdo)
 
 function version_1(PDO $pdo)
 {
-    $pdo->exec("CREATE TABLE users (
+    $pdo->exec('CREATE TABLE users (
         id INT AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(50) NOT NULL UNIQUE,
         password VARCHAR(255) NOT NULL,
@@ -31,13 +31,13 @@ function version_1(PDO $pdo)
         feed_token VARCHAR(255) NOT NULL UNIQUE,
         fever_token VARCHAR(255) NOT NULL UNIQUE,
         fever_api_key VARCHAR(255) NOT NULL UNIQUE
-    )");
+    )');
 
     $pdo->exec('CREATE TABLE user_settings (
-        "user_id" INT NOT NULL,
-        "key" VARCHAR(255) NOT NULL,
-        "value" TEXT NOT NULL,
-        PRIMARY KEY("user_id", "key"),
+        `user_id` INT NOT NULL,
+        `key` VARCHAR(255) NOT NULL,
+        `value` TEXT NOT NULL,
+        PRIMARY KEY(`user_id`, `key`),
         FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
     )');
 
@@ -80,7 +80,7 @@ function version_1(PDO $pdo)
         UNIQUE(feed_id, checksum)
     )');
 
-    $pdo->exec('CREATE TABLE "groups" (
+    $pdo->exec('CREATE TABLE `groups` (
         id INT AUTO_INCREMENT PRIMARY KEY, 
         user_id INT NOT NULL,
         title VARCHAR(255) NOT NULL,
@@ -88,7 +88,7 @@ function version_1(PDO $pdo)
         UNIQUE(user_id, title)
     )');
 
-    $pdo->exec('CREATE TABLE "feeds_groups" (
+    $pdo->exec('CREATE TABLE `feeds_groups` (
         feed_id BIGINT NOT NULL,
         group_id INT NOT NULL,
         PRIMARY KEY(feed_id, group_id),
@@ -102,7 +102,7 @@ function version_1(PDO $pdo)
         type VARCHAR(50)
     )');
 
-    $pdo->exec('CREATE TABLE "favicons_feeds" (
+    $pdo->exec('CREATE TABLE `favicons_feeds` (
         feed_id BIGINT NOT NULL,
         favicon_id INT NOT NULL,
         PRIMARY KEY(feed_id, favicon_id),

--- a/app/schemas/mysql.php
+++ b/app/schemas/mysql.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Miniflux\Schema;
+
+use PDO;
+use Miniflux\Helper;
+
+const VERSION = 3;
+
+function version_3(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE feeds ADD COLUMN expiration BIGINT DEFAULT 0');
+}
+
+function version_2(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE feeds ADD COLUMN parsing_error_message VARCHAR(255)');
+}
+
+function version_1(PDO $pdo)
+{
+    $pdo->exec("CREATE TABLE users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        username VARCHAR(50) NOT NULL UNIQUE,
+        password VARCHAR(255) NOT NULL,
+        is_admin TINYINT(1) DEFAULT FALSE,
+        last_login BIGINT,
+        api_token VARCHAR(255) NOT NULL UNIQUE,
+        bookmarklet_token VARCHAR(255) NOT NULL UNIQUE,
+        cronjob_token VARCHAR(255) NOT NULL UNIQUE,
+        feed_token VARCHAR(255) NOT NULL UNIQUE,
+        fever_token VARCHAR(255) NOT NULL UNIQUE,
+        fever_api_key VARCHAR(255) NOT NULL UNIQUE
+    )");
+
+    $pdo->exec('CREATE TABLE user_settings (
+        "user_id" INT NOT NULL,
+        "key" VARCHAR(255) NOT NULL,
+        "value" TEXT NOT NULL,
+        PRIMARY KEY("user_id", "key"),
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+    )');
+
+    $pdo->exec('CREATE TABLE feeds (
+        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL,
+        feed_url VARCHAR(255) NOT NULL,
+        site_url VARCHAR(255),
+        title VARCHAR(255) NOT NULL,
+        last_checked BIGINT DEFAULT 0,
+        last_modified VARCHAR(255),
+        etag VARCHAR(255),
+        enabled TINYINT(1) DEFAULT TRUE,
+        download_content TINYINT(1) DEFAULT FALSE,
+        parsing_error INT DEFAULT 0,
+        rtl TINYINT(1) DEFAULT FALSE,
+        cloak_referrer TINYINT(1) DEFAULT FALSE,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+        UNIQUE(user_id, feed_url)
+    )');
+
+    $pdo->exec('CREATE TABLE items (
+        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL,
+        feed_id BIGINT NOT NULL,
+        checksum VARCHAR(255) NOT NULL,
+        status VARCHAR(10) NOT NULL,
+        bookmark INT DEFAULT 0,
+        url TEXT NOT NULL,
+        title TEXT NOT NULL,
+        author TEXT,
+        content TEXT,
+        updated BIGINT,
+        enclosure_url TEXT,
+        enclosure_type VARCHAR(50),
+        language VARCHAR(50),
+        rtl TINYINT(1) DEFAULT FALSE,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE,
+        UNIQUE(feed_id, checksum)
+    )');
+
+    $pdo->exec('CREATE TABLE "groups" (
+        id INT AUTO_INCREMENT PRIMARY KEY, 
+        user_id INT NOT NULL,
+        title VARCHAR(255) NOT NULL,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+        UNIQUE(user_id, title)
+    )');
+
+    $pdo->exec('CREATE TABLE "feeds_groups" (
+        feed_id BIGINT NOT NULL,
+        group_id INT NOT NULL,
+        PRIMARY KEY(feed_id, group_id),
+        FOREIGN KEY(group_id) REFERENCES groups(id) ON DELETE CASCADE,
+        FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+    )');
+
+    $pdo->exec('CREATE TABLE favicons (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        hash VARCHAR(255) UNIQUE,
+        type VARCHAR(50)
+    )');
+
+    $pdo->exec('CREATE TABLE "favicons_feeds" (
+        feed_id BIGINT NOT NULL,
+        favicon_id INT NOT NULL,
+        PRIMARY KEY(feed_id, favicon_id),
+        FOREIGN KEY(favicon_id) REFERENCES favicons(id) ON DELETE CASCADE,
+        FOREIGN KEY(feed_id) REFERENCES feeds(id) ON DELETE CASCADE
+    )');
+
+    $pdo->exec('CREATE TABLE remember_me (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        user_id INT NOT NULL,
+        ip VARCHAR(255),
+        user_agent VARCHAR(255),
+        token VARCHAR(255),
+        sequence VARCHAR(255),
+        expiration BIGINT,
+        date_creation BIGINT,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+    )');
+
+    $fever_token = Helper\generate_token();
+    $rq = $pdo->prepare('
+      INSERT INTO users
+      (username, password, is_admin, api_token, bookmarklet_token, cronjob_token, feed_token, fever_token, fever_api_key)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ');
+
+    $rq->execute(array(
+        'admin',
+        password_hash('admin', PASSWORD_BCRYPT),
+        '1',
+        Helper\generate_token(),
+        Helper\generate_token(),
+        Helper\generate_token(),
+        Helper\generate_token(),
+        $fever_token,
+        md5('admin:'.$fever_token),
+    ));
+
+    $pdo->exec('CREATE INDEX items_user_status_idx ON items(user_id, status)');
+    $pdo->exec('CREATE INDEX items_user_feed_idx ON items(user_id, feed_id)');
+}

--- a/config.default.php
+++ b/config.default.php
@@ -15,7 +15,7 @@ define('FAVICON_DIRECTORY', DATA_DIRECTORY.DIRECTORY_SEPARATOR.'favicons');
 // FAVICON_URL_PATH => default is data/favicons/
 define('FAVICON_URL_PATH', 'data/favicons');
 
-// Database driver: "sqlite" or "postgres", default is sqlite
+// Database driver: "sqlite", "postgres", or "mysql" default is sqlite
 define('DB_DRIVER', 'sqlite');
 
 // Database connection parameters when Postgres is used

--- a/docs/config.markdown
+++ b/docs/config.markdown
@@ -12,7 +12,7 @@ To override them, rename the file `config.default.php` to `config.php`.
 Database configuration
 ----------------------
 
-By default, Miniflux uses Sqlite but Postgres is also supported.
+By default, Miniflux uses Sqlite but Postgres and mysql are also supported.
 
 ### Sqlite configuration
 
@@ -43,6 +43,26 @@ define('DB_USERNAME', 'my postgres user');
 define('DB_PASSWORD', 'my secret password');
 ```
 
+### MySQL configuration
+
+Miniflux will creates the schema automatically but not the database itself:
+
+```sql
+CREATE DATABASE miniflux;
+```
+
+The `config.php` have to be modified as well:
+
+```php
+define('DB_DRIVER', 'mysql');
+
+// Replace these values:
+define('DB_HOSTNAME', 'localhost');
+define('DB_NAME', 'miniflux');
+define('DB_USERNAME', 'my mysql user');
+define('DB_PASSWORD', 'my secret password');
+```
+
 List of parameters
 ------------------
 
@@ -64,10 +84,10 @@ define('FAVICON_DIRECTORY', DATA_DIRECTORY.DIRECTORY_SEPARATOR.'favicons');
 // FAVICON_URL_PATH => default is data/favicons/
 define('FAVICON_URL_PATH', 'data/favicons');
 
-// Database driver: "sqlite" or "postgres", default is sqlite
+// Database driver: "sqlite", "postgres", or "mysql" default is sqlite
 define('DB_DRIVER', 'sqlite');
 
-// Database connection parameters when Postgres is used
+// Database connection parameters when Postgres or Mysql are used
 define('DB_HOSTNAME', 'localhost');
 define('DB_NAME', 'miniflux');
 define('DB_USERNAME', 'postgres');

--- a/docs/config.markdown
+++ b/docs/config.markdown
@@ -12,7 +12,7 @@ To override them, rename the file `config.default.php` to `config.php`.
 Database configuration
 ----------------------
 
-By default, Miniflux uses Sqlite but Postgres and mysql are also supported.
+By default, Miniflux uses Sqlite but Postgres and MySQL are also supported.
 
 ### Sqlite configuration
 
@@ -87,11 +87,11 @@ define('FAVICON_URL_PATH', 'data/favicons');
 // Database driver: "sqlite", "postgres", or "mysql" default is sqlite
 define('DB_DRIVER', 'sqlite');
 
-// Database connection parameters when Postgres or Mysql are used
+// Database connection parameters when Postgres or MySQL are used
 define('DB_HOSTNAME', 'localhost');
 define('DB_NAME', 'miniflux');
-define('DB_USERNAME', 'postgres');
-define('DB_PASSWORD', '');
+define('DB_USERNAME', 'my db user');
+define('DB_PASSWORD', 'my secret password');
 
 // DB_FILENAME => database file when Sqlite is used
 define('DB_FILENAME', DATA_DIRECTORY.'/db.sqlite');

--- a/docs/installation.markdown
+++ b/docs/installation.markdown
@@ -27,7 +27,7 @@ Installation
 1. `git clone https://github.com/miniflux/miniflux.git`
 2. Go to the third step just above
 
-By default, Miniflux uses Sqlite, if you would like to use Postgres instead you will have to modify your `config.php` file.
+By default, Miniflux uses Sqlite, if you would like to use Postgres or MySQL instead you will have to modify your `config.php` file.
 
 Security
 --------

--- a/scripts/migrate-db.php
+++ b/scripts/migrate-db.php
@@ -32,6 +32,10 @@ function get_last_id(PDO $pdo)
         $rq = $pdo->prepare('SELECT LASTVAL()');
         $rq->execute();
         return $rq->fetchColumn();
+    } elseif (DB_DRIVER === 'mysql') {
+        $rq = $pdo->prepare('SELECT LAST_INSERT_ID()');
+        $rq->execute();
+        return $rq->fetchColumn();
     }
 
     return $pdo->lastInsertId();

--- a/tests/ci/config.mysql.php
+++ b/tests/ci/config.mysql.php
@@ -1,0 +1,7 @@
+<?php
+
+defined('DB_DRIVER') or define('DB_DRIVER', 'mysql');
+defined('DB_HOSTNAME') or define('DB_HOSTNAME', 'localhost');
+defined('DB_NAME') or define('DB_NAME', 'miniflux_functional_test');
+defined('DB_USERNAME') or define('DB_USERNAME', 'root');
+defined('DB_PASSWORD') or define('DB_PASSWORD', '');

--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -8,6 +8,7 @@ fi
 
 echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 echo "always_populate_raw_post_data = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+echo "opcache.enable = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
 

--- a/tests/functional/BaseApiTest.php
+++ b/tests/functional/BaseApiTest.php
@@ -23,7 +23,7 @@ abstract class BaseApiTest extends PHPUnit_Framework_TestCase
                 $pdo->exec('KILL '.$row['id']);
             }
             $pdo->exec('DROP DATABASE '.DB_NAME);
-            $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
+            $pdo->exec('CREATE DATABASE '.DB_NAME);
             $pdo = null;
         } else if (file_exists(DB_FILENAME)) {
             unlink(DB_FILENAME);

--- a/tests/functional/BaseApiTest.php
+++ b/tests/functional/BaseApiTest.php
@@ -16,6 +16,15 @@ abstract class BaseApiTest extends PHPUnit_Framework_TestCase
             $pdo->exec('DROP DATABASE '.DB_NAME);
             $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
             $pdo = null;
+        } else if (DB_DRIVER === 'mysql') {
+            $pdo = new PDO('mysql:host='.DB_HOSTNAME, DB_USERNAME, DB_PASSWORD);
+            $stmt = $pdo->query("SELECT information_schema.processlist.id FROM information_schema.processlist WHERE information_schema.processlist.DB = '".DB_NAME."' AND id <> connection_id()");
+            while($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                $pdo->exec('KILL '.$row['id']);
+            }
+            $pdo->exec('DROP DATABASE '.DB_NAME);
+            $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
+            $pdo = null;
         } else if (file_exists(DB_FILENAME)) {
             unlink(DB_FILENAME);
         }

--- a/tests/phpunit.functional.mysql.xml
+++ b/tests/phpunit.functional.mysql.xml
@@ -1,0 +1,15 @@
+<phpunit stopOnError="true" stopOnFailure="true" colors="true">
+    <testsuites>
+        <testsuite name="Miniflux MySQL Functional Tests">
+            <directory>functional</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <const name="API_URL" value="http://127.0.0.1/jsonrpc.php" />
+        <const name="FEVER_API_URL" value="http://127.0.0.1/fever/" />
+        <const name="DB_DRIVER" value="mysql" />
+        <const name="DB_USERNAME" value="root" />
+        <const name="DB_PASSWORD" value="" />
+        <const name="DB_NAME" value="miniflux_functional_test" />
+    </php>
+</phpunit>

--- a/tests/phpunit.unit.mysql.xml
+++ b/tests/phpunit.unit.mysql.xml
@@ -1,0 +1,13 @@
+<phpunit stopOnError="true" stopOnFailure="true" colors="true">
+    <testsuites>
+        <testsuite name="Miniflux MySQL Unit Tests">
+            <directory>unit</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <const name="DB_DRIVER" value="mysql" />
+        <const name="DB_USERNAME" value="root" />
+        <const name="DB_PASSWORD" value="" />
+        <const name="DB_NAME" value="miniflux_unit_test" />
+    </php>
+</phpunit>

--- a/tests/unit/BaseTest.php
+++ b/tests/unit/BaseTest.php
@@ -20,7 +20,7 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
         } else if (DB_DRIVER === 'mysql') {
             $pdo = new PDO('mysql:host='.DB_HOSTNAME, DB_USERNAME, DB_PASSWORD);
             $pdo->exec('DROP DATABASE '.DB_NAME);
-            $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
+            $pdo->exec('CREATE DATABASE '.DB_NAME);
             $pdo = null;
         }
 

--- a/tests/unit/BaseTest.php
+++ b/tests/unit/BaseTest.php
@@ -17,6 +17,11 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
             $pdo->exec('DROP DATABASE '.DB_NAME);
             $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
             $pdo = null;
+        } else if (DB_DRIVER === 'mysql') {
+            $pdo = new PDO('mysql:host='.DB_HOSTNAME, DB_USERNAME, DB_PASSWORD);
+            $pdo->exec('DROP DATABASE '.DB_NAME);
+            $pdo->exec('CREATE DATABASE '.DB_NAME.' WITH OWNER '.DB_USERNAME);
+            $pdo = null;
         }
 
         PicoDb\Database::setInstance('db', function () {


### PR DESCRIPTION
I've added a new schema for MySQL, updated all of the supporting functions, updated the documentation and expanded the unit testing/ci to cover MySQL.

In order for travis to pass the builds I had disabled opcache on php5.6 and php7 as it was introducing problems when swapping between the config.(_postgres|mysql_).php files.