### PR TITLE
Clearer indication for wallabag configuration URL

### DIFF
--- a/app/locales/ar_AR/translations.php
+++ b/app/locales/ar_AR/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/cs_CZ/translations.php
+++ b/app/locales/cs_CZ/translations.php
@@ -242,7 +242,7 @@ return array(
     'Administrator' => 'Administrátor',
     '%e %B %Y %k:%M' => '%e. %B %Y %k:%M',
     'Wallabag' => 'Wallabag',
-    'Wallabag API URL' => 'Wallabag API URL',
+    'Wallabag URL' => 'Wallabag URL',
     'Wallabag Client ID' => 'Wallabag ID klienta',
     'Wallabag Client Secret' => 'Wallabag heslo klienta',
     'Action' => 'Akce',

--- a/app/locales/de_DE/translations.php
+++ b/app/locales/de_DE/translations.php
@@ -242,7 +242,7 @@ return array(
     'Administrator' => 'Administrator',
     '%e %B %Y %k:%M' => '%e %B %Y %k:%M',
     'Wallabag' => 'Wallabag',
-    'Wallabag API URL' => 'Wallabag-API-URL',
+    'Wallabag URL' => 'Wallabag URL',
     'Wallabag Client ID' => 'Wallabag-Client-ID',
     'Wallabag Client Secret' => 'Wallabag-Client-Secret',
     'Action' => 'Aktion',

--- a/app/locales/es_ES/translations.php
+++ b/app/locales/es_ES/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/fr_FR/translations.php
+++ b/app/locales/fr_FR/translations.php
@@ -242,7 +242,7 @@ return array(
     'Administrator' => 'Administrateur',
     '%e %B %Y %k:%M' => '%e %B %Y %k:%M',
     'Wallabag' => 'Wallabag',
-    'Wallabag API URL' => 'URL de l\'API de Wallabag',
+    'Wallabag URL' => 'URL de Wallabag',
     'Wallabag Client ID' => 'ID client de Wallbag',
     'Wallabag Client Secret' => 'Clé secrète de Wallabag',
     'Action' => 'Action',

--- a/app/locales/it_IT/translations.php
+++ b/app/locales/it_IT/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/ja_JP/translations.php
+++ b/app/locales/ja_JP/translations.php
@@ -244,7 +244,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/pt_BR/translations.php
+++ b/app/locales/pt_BR/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/ru_RU/translations.php
+++ b/app/locales/ru_RU/translations.php
@@ -242,7 +242,7 @@ return array(
     'Administrator' => 'Администратор',
     '%e %B %Y %k:%M' => '%e %B %Y %k:%M',
     'Wallabag' => 'Wallabag',
-    'Wallabag API URL' => 'Wallabag API URL',
+    'Wallabag URL' => 'Wallabag URL',
     'Wallabag Client ID' => 'Wallabag Client ID',
     'Wallabag Client Secret' => 'Wallabag Client Secret',
     'Action' => 'Действие',

--- a/app/locales/sr_RS/translations.php
+++ b/app/locales/sr_RS/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/sr_RS@latin/translations.php
+++ b/app/locales/sr_RS@latin/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/tr_TR/translations.php
+++ b/app/locales/tr_TR/translations.php
@@ -242,7 +242,7 @@ return array(
     // 'Administrator' => '',
     // '%e %B %Y %k:%M' => '',
     // 'Wallabag' => '',
-    // 'Wallabag API URL' => '',
+    // 'Wallabag URL' => '',
     // 'Wallabag Client ID' => '',
     // 'Wallabag Client Secret' => '',
     // 'Action' => '',

--- a/app/locales/zh_CN/translations.php
+++ b/app/locales/zh_CN/translations.php
@@ -242,7 +242,7 @@ return array(
     'Administrator' => '管理员',
     '%e %B %Y %k:%M' => '%e %B %Y %k:%M',
     'Wallabag' => 'Wallabag',
-    'Wallabag API URL' => 'Wallabag API URL',
+    'Wallabag URL' => 'Wallabag URL',
     'Wallabag Client ID' => 'Wallabag 客户端 ID',
     'Wallabag Client Secret' => 'Wallabag 客户端 Secret',
     'Action' => '操作',

--- a/app/templates/services.php
+++ b/app/templates/services.php
@@ -47,7 +47,7 @@
     <div class="options">
         <?php echo Miniflux\Helper\form_checkbox('wallabag_enabled', t('Send bookmarks to Wallabag'), 1, isset($values['wallabag_enabled']) && $values['wallabag_enabled'] == 1) ?><br />
 
-        <?php echo Miniflux\Helper\form_label(t('Wallabag API URL'), 'wallabag_url') ?>
+        <?php echo Miniflux\Helper\form_label(t('Wallabag URL'), 'wallabag_url') ?>
         <?php echo Miniflux\Helper\form_text('wallabag_url', $values, $errors) ?><br/>
 
         <?php echo Miniflux\Helper\form_label(t('Wallabag Client ID'), 'wallabag_client_id') ?>


### PR DESCRIPTION
The wallabag configuration API URL was not so clear for users. This is just the wallabag instance URL needed here.
@nicosomb was a little bit quick with #621 so I think you can use this one instead. I hope I changed everything. If not, let me know.