### PR TITLE
New mysql schema supports utf8mb4 on selected columns

### DIFF
--- a/app/core/database.php
+++ b/app/core/database.php
@@ -47,7 +47,7 @@ function get_connection_parameters()
             'password' => DB_PASSWORD,
             'database' => DB_NAME,
             'port'     => DB_PORT,
-            'charset'  => 'utf8',
+            'charset'  => 'utf8mb4',
         );
     } else {
         require_once __DIR__.'/../schemas/sqlite.php';

--- a/app/schemas/mysql.php
+++ b/app/schemas/mysql.php
@@ -5,7 +5,14 @@ namespace Miniflux\Schema;
 use PDO;
 use Miniflux\Helper;
 
-const VERSION = 1;
+const VERSION = 2;
+
+function version_2(PDO $pdo)
+{
+    $pdo->exec('ALTER TABLE items CHANGE title title TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL');
+    $pdo->exec('ALTER TABLE items CHANGE author author TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+    $pdo->exec('ALTER TABLE items CHANGE content content LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+}
 
 function version_1(PDO $pdo)
 {

--- a/app/schemas/mysql.php
+++ b/app/schemas/mysql.php
@@ -12,6 +12,7 @@ function version_2(PDO $pdo)
     $pdo->exec('ALTER TABLE items CHANGE title title TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL');
     $pdo->exec('ALTER TABLE items CHANGE author author TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
     $pdo->exec('ALTER TABLE items CHANGE content content LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+    $pdo->exec('ALTER TABLE feeds CHANGE title title VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
 }
 
 function version_1(PDO $pdo)


### PR DESCRIPTION
Support for 4-byte utf8 in the title, author, and content columns of the items table and title column in the feeds table.

Note this does not cover any other column. Charset was customised on a column by column basis as it avoids truncating columns (where there is a unique index) that would potentially affect portability with other database drivers.

I believe the columns chosen would likely represent the set of columns where data holding 4-byte utf8 may be found, happy to add more to the PR on your advice @fguillot.