### PR TITLE
Scrape parent element for iframe

### DIFF
--- a/reader/scraper/scraper.go
+++ b/reader/scraper/scraper.go
@@ -72,7 +72,7 @@ func scrapContent(page io.Reader, rules string) (string, error) {
 		var content string
 
 		// For some inline elements, we get the parent.
-		if s.Is("img") {
+		if s.Is("img") || s.Is("iframe") {
 			content, _ = s.Parent().Html()
 		} else {
 			content, _ = s.Html()


### PR DESCRIPTION
Current behavior: if you have an `iframe` scraper rule, `scrapContent`
tries to return the inner HTML of the `iframe`, which turns up blank.

New behavior: like `img` elements, if an `iframe` is matched by a scraper rule,
the parent element's inner HTML (i.e. the `iframe` is returned).