### PR TITLE
Fever API: If there are no items to return, return an empty JSON array

### DIFF
--- a/fever/fever.go
+++ b/fever/fever.go
@@ -386,7 +386,7 @@ func (c *Controller) handleItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-    result.Items = make([]item, 0)
+	result.Items = make([]item, 0)
 	for _, entry := range entries {
 		isRead := 0
 		if entry.Status == model.EntryStatusRead {

--- a/fever/fever.go
+++ b/fever/fever.go
@@ -386,6 +386,7 @@ func (c *Controller) handleItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+    result.Items = make([]item, 0)
 	for _, entry := range entries {
 		isRead := 0
 		if entry.Status == model.EntryStatusRead {


### PR DESCRIPTION
Fever API says an empty JSON array is returned when there are no more items to return. 

However, miniflux was omiting the key 'items' from the response entirely when there are no items to return. GO's slice in the return object is initialized to nil and hence json marshal omits the field entirely. This was causing ReadKit on mac to crash on every incremental sync.