### PR TITLE
Add since and join parameters to entries endpoints

### DIFF
--- a/api/entry.go
+++ b/api/entry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/miniflux/miniflux/http/request"
 	"github.com/miniflux/miniflux/http/response/json"
 	"github.com/miniflux/miniflux/model"
+	"time"
 )
 
 // GetFeedEntry is the API handler to get a single feed entry.
@@ -102,6 +103,7 @@ func (c *Controller) GetFeedEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	since := request.QueryInt64Param(r, "since", 0)
 	limit := request.QueryIntParam(r, "limit", 100)
 	offset := request.QueryIntParam(r, "offset", 0)
 	if err := model.ValidateRange(offset, limit); err != nil {
@@ -115,6 +117,12 @@ func (c *Controller) GetFeedEntries(w http.ResponseWriter, r *http.Request) {
 	builder.WithOrder(order)
 	builder.WithDirection(direction)
 	builder.WithOffset(offset)
+
+	if since > 0 {
+		t := time.Unix(since, 0)
+		builder.WithSince(&t)
+	}
+
 	builder.WithLimit(limit)
 
 	entries, err := builder.GetEntries()
@@ -154,6 +162,7 @@ func (c *Controller) GetEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	since := request.QueryInt64Param(r, "since", 0)
 	limit := request.QueryIntParam(r, "limit", 100)
 	offset := request.QueryIntParam(r, "offset", 0)
 	if err := model.ValidateRange(offset, limit); err != nil {
@@ -167,6 +176,11 @@ func (c *Controller) GetEntries(w http.ResponseWriter, r *http.Request) {
 	builder.WithDirection(direction)
 	builder.WithOffset(offset)
 	builder.WithLimit(limit)
+
+	if since > 0 {
+		t := time.Unix(since, 0)
+		builder.WithSince(&t)
+	}
 
 	entries, err := builder.GetEntries()
 	if err != nil {

--- a/api/entry.go
+++ b/api/entry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/miniflux/miniflux/http/response/json"
 	"github.com/miniflux/miniflux/model"
 	"time"
+	"fmt"
 )
 
 // GetFeedEntry is the API handler to get a single feed entry.
@@ -103,6 +104,12 @@ func (c *Controller) GetFeedEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	join := request.QueryParam(r, "join", model.DefaultJoin)
+	if err := model.ValidateJoin(join); err != nil {
+		json.BadRequest(w, err)
+		return
+	}
+
 	since := request.QueryInt64Param(r, "since", 0)
 	limit := request.QueryIntParam(r, "limit", 100)
 	offset := request.QueryIntParam(r, "offset", 0)
@@ -117,6 +124,7 @@ func (c *Controller) GetFeedEntries(w http.ResponseWriter, r *http.Request) {
 	builder.WithOrder(order)
 	builder.WithDirection(direction)
 	builder.WithOffset(offset)
+	builder.WithJoin(join == "enabled")
 
 	if since > 0 {
 		t := time.Unix(since, 0)
@@ -162,6 +170,12 @@ func (c *Controller) GetEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	join := request.QueryParam(r, "join", model.DefaultJoin)
+	if err := model.ValidateJoin(join); err != nil {
+		json.BadRequest(w, err)
+		return
+	}
+
 	since := request.QueryInt64Param(r, "since", 0)
 	limit := request.QueryIntParam(r, "limit", 100)
 	offset := request.QueryIntParam(r, "offset", 0)
@@ -176,6 +190,7 @@ func (c *Controller) GetEntries(w http.ResponseWriter, r *http.Request) {
 	builder.WithDirection(direction)
 	builder.WithOffset(offset)
 	builder.WithLimit(limit)
+	builder.WithJoin(join == "enabled")
 
 	if since > 0 {
 		t := time.Unix(since, 0)
@@ -184,7 +199,7 @@ func (c *Controller) GetEntries(w http.ResponseWriter, r *http.Request) {
 
 	entries, err := builder.GetEntries()
 	if err != nil {
-		json.ServerError(w, errors.New("Unable to fetch the list of entries"))
+		json.ServerError(w, fmt.Errorf("Unable to fetch the list of entries %v", err))
 		return
 	}
 

--- a/http/request/request.go
+++ b/http/request/request.go
@@ -82,6 +82,25 @@ func QueryIntParam(r *http.Request, param string, defaultValue int) int {
 	return val
 }
 
+// QueryInt64Param returns a querystring parameter as integer.
+func QueryInt64Param(r *http.Request, param string, defaultValue int64) int64 {
+	value := r.URL.Query().Get(param)
+	if value == "" {
+		return defaultValue
+	}
+
+	val, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return defaultValue
+	}
+
+	if val < 0 {
+		return defaultValue
+	}
+
+	return val
+}
+
 // HasQueryParam checks if the query string contains the given parameter.
 func HasQueryParam(r *http.Request, param string) bool {
 	values := r.URL.Query()

--- a/model/entry.go
+++ b/model/entry.go
@@ -16,6 +16,7 @@ const (
 	EntryStatusRemoved      = "removed"
 	DefaultSortingOrder     = "published_at"
 	DefaultSortingDirection = "asc"
+	DefaultJoin             = "enabled"
 )
 
 // Entry represents a feed item in the system.
@@ -68,6 +69,15 @@ func ValidateDirection(direction string) error {
 	}
 
 	return fmt.Errorf(`Invalid direction, valid direction values are: "asc" or "desc"`)
+}
+
+// ValidateJoin makes sure the join parameter is valid.
+func ValidateJoin(join string) error {
+	switch join {
+	case "enabled", "disabled":
+		return nil
+	}
+	return fmt.Errorf(`Invalid join, valid join values are: "enabled" or "disabled"`)
 }
 
 // ValidateRange makes sure the offset/limit values are valid.

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -33,6 +33,7 @@ type EntryQueryBuilder struct {
 	entryIDs           []int64
 	since              *time.Time
 	before             *time.Time
+	join               bool
 	starred            bool
 }
 
@@ -107,6 +108,11 @@ func (e *EntryQueryBuilder) WithLimit(limit int) *EntryQueryBuilder {
 	e.limit = limit
 	return e
 }
+// WithFeedOption set the feed option.
+func (e *EntryQueryBuilder) WithJoin(join bool) *EntryQueryBuilder {
+	e.join = join
+	return e
+}
 
 // WithSince set the since filter.
 func (e *EntryQueryBuilder) WithSince(date *time.Time) *EntryQueryBuilder {
@@ -165,21 +171,33 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 	query := `
 		SELECT
 		e.id, e.user_id, e.feed_id, e.hash, e.published_at at time zone u.timezone, e.title,
-		e.url, e.comments_url, e.author, e.content, e.status, e.starred,
-		f.title as feed_title, f.feed_url, f.site_url, f.checked_at,
-		f.category_id, c.title as category_title, f.scraper_rules, f.rewrite_rules, f.crawler,
-		fi.icon_id,
-		u.timezone
+		e.url, e.comments_url, e.author, e.content, e.status, e.starred, u.timezone
+
+		%s
+
 		FROM entries e
-		LEFT JOIN feeds f ON f.id=e.feed_id
-		LEFT JOIN categories c ON c.id=f.category_id
-		LEFT JOIN feed_icons fi ON fi.feed_id=f.id
+		%s
 		LEFT JOIN users u ON u.id=e.user_id
 		WHERE %s %s
 	`
 
+	// Leading comma is important
+	join_bind := `, f.title as feed_title, f.feed_url, f.site_url, f.checked_at,
+		f.category_id, c.title as category_title, f.scraper_rules, f.rewrite_rules, f.crawler,
+		fi.icon_id
+	`
+	join_command := `LEFT JOIN feeds f ON f.id=e.feed_id
+		LEFT JOIN categories c ON c.id=f.category_id
+		LEFT JOIN feed_icons fi ON fi.feed_id=f.id
+	`
+
+	if !e.join {
+		join_bind = ""
+		join_command = ""
+	}
+
 	args, conditions := e.buildCondition()
-	query = fmt.Sprintf(query, conditions, e.buildSorting())
+	query = fmt.Sprintf(query, join_bind, join_command, conditions, e.buildSorting())
 	// log.Println(query)
 
 	rows, err := e.store.db.Query(query, args...)
@@ -194,52 +212,76 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 		var iconID interface{}
 		var tz string
 
-		entry.Feed = &model.Feed{UserID: e.userID}
-		entry.Feed.Category = &model.Category{UserID: e.userID}
-		entry.Feed.Icon = &model.FeedIcon{}
+		var err error
+		if e.join {
+			entry.Feed = &model.Feed{UserID: e.userID}
+			entry.Feed.Category = &model.Category{UserID: e.userID}
+			entry.Feed.Icon = &model.FeedIcon{}
 
-		err := rows.Scan(
-			&entry.ID,
-			&entry.UserID,
-			&entry.FeedID,
-			&entry.Hash,
-			&entry.Date,
-			&entry.Title,
-			&entry.URL,
-			&entry.CommentsURL,
-			&entry.Author,
-			&entry.Content,
-			&entry.Status,
-			&entry.Starred,
-			&entry.Feed.Title,
-			&entry.Feed.FeedURL,
-			&entry.Feed.SiteURL,
-			&entry.Feed.CheckedAt,
-			&entry.Feed.Category.ID,
-			&entry.Feed.Category.Title,
-			&entry.Feed.ScraperRules,
-			&entry.Feed.RewriteRules,
-			&entry.Feed.Crawler,
-			&iconID,
-			&tz,
-		)
+			err = rows.Scan(
+				&entry.ID,
+				&entry.UserID,
+				&entry.FeedID,
+				&entry.Hash,
+				&entry.Date,
+				&entry.Title,
+				&entry.URL,
+				&entry.CommentsURL,
+				&entry.Author,
+				&entry.Content,
+				&entry.Status,
+				&entry.Starred,
+				&tz,
+
+				// Join
+				&entry.Feed.Title,
+				&entry.Feed.FeedURL,
+				&entry.Feed.SiteURL,
+				&entry.Feed.CheckedAt,
+				&entry.Feed.Category.ID,
+				&entry.Feed.Category.Title,
+				&entry.Feed.ScraperRules,
+				&entry.Feed.RewriteRules,
+				&entry.Feed.Crawler,
+				&iconID,
+			)
+
+			if iconID == nil {
+				entry.Feed.Icon.IconID = 0
+			} else {
+				entry.Feed.Icon.IconID = iconID.(int64)
+			}
+
+			entry.Feed.CheckedAt = timezone.Convert(tz, entry.Feed.CheckedAt)
+			entry.Feed.ID = entry.FeedID
+			entry.Feed.Icon.FeedID = entry.FeedID
+
+		} else {
+			entry.Feed = nil
+
+			err = rows.Scan(
+				&entry.ID,
+				&entry.UserID,
+				&entry.FeedID,
+				&entry.Hash,
+				&entry.Date,
+				&entry.Title,
+				&entry.URL,
+				&entry.CommentsURL,
+				&entry.Author,
+				&entry.Content,
+				&entry.Status,
+				&entry.Starred,
+				&tz,
+			)
+		}
 
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch entry row: %v", err)
 		}
 
-		if iconID == nil {
-			entry.Feed.Icon.IconID = 0
-		} else {
-			entry.Feed.Icon.IconID = iconID.(int64)
-		}
-
 		// Make sure that timestamp fields contains timezone information (API)
 		entry.Date = timezone.Convert(tz, entry.Date)
-		entry.Feed.CheckedAt = timezone.Convert(tz, entry.Feed.CheckedAt)
-
-		entry.Feed.ID = entry.FeedID
-		entry.Feed.Icon.FeedID = entry.FeedID
 		entries = append(entries, &entry)
 	}
 

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -108,7 +108,7 @@ func (e *EntryQueryBuilder) WithLimit(limit int) *EntryQueryBuilder {
 	e.limit = limit
 	return e
 }
-// WithFeedOption set the feed option.
+// WithJoin set the feed option.
 func (e *EntryQueryBuilder) WithJoin(join bool) *EntryQueryBuilder {
 	e.join = join
 	return e
@@ -182,22 +182,22 @@ func (e *EntryQueryBuilder) GetEntries() (model.Entries, error) {
 	`
 
 	// Leading comma is important
-	join_bind := `, f.title as feed_title, f.feed_url, f.site_url, f.checked_at,
+	joinBind := `, f.title as feed_title, f.feed_url, f.site_url, f.checked_at,
 		f.category_id, c.title as category_title, f.scraper_rules, f.rewrite_rules, f.crawler,
 		fi.icon_id
 	`
-	join_command := `LEFT JOIN feeds f ON f.id=e.feed_id
+	joinCommand := `LEFT JOIN feeds f ON f.id=e.feed_id
 		LEFT JOIN categories c ON c.id=f.category_id
 		LEFT JOIN feed_icons fi ON fi.feed_id=f.id
 	`
 
 	if !e.join {
-		join_bind = ""
-		join_command = ""
+		joinBind = ""
+		joinCommand = ""
 	}
 
 	args, conditions := e.buildCondition()
-	query = fmt.Sprintf(query, join_bind, join_command, conditions, e.buildSorting())
+	query = fmt.Sprintf(query, joinBind, joinCommand, conditions, e.buildSorting())
 	// log.Println(query)
 
 	rows, err := e.store.db.Query(query, args...)


### PR DESCRIPTION
You can now request only entries that have been published since your provided UNIX timestamp via a `since` parameter.

I was also able to add a `join` parameter to toggle whether an entry's feed object gets joined into the entry itself. When `join=disabled` is sent as a URL parameter, entry JSON objects will contain a `feed_id` field rather than the `feed`, `category`, and `icon` objects that they normally have.

Closes #124