### PR TITLE
Updated Sanitizer to better handle noscript tags.

### DIFF
--- a/reader/sanitizer/sanitizer.go
+++ b/reader/sanitizer/sanitizer.go
@@ -82,8 +82,6 @@ func Sanitize(baseURL, input string) string {
 						buffer.WriteString("<" + tagName + "/>")
 					}
 				}
-			} else if tagName == "noscript" {
-				noscriptDepth--
 			}
 		}
 	}

--- a/reader/sanitizer/sanitizer.go
+++ b/reader/sanitizer/sanitizer.go
@@ -25,7 +25,7 @@ func Sanitize(baseURL, input string) string {
 	tokenizer := html.NewTokenizer(bytes.NewBufferString(input))
 	var buffer bytes.Buffer
 	var tagStack []string
-	noscriptDepth := 0
+	scriptTagDepth := 0
 
 	for {
 		if tokenizer.Next() == html.ErrorToken {
@@ -40,7 +40,7 @@ func Sanitize(baseURL, input string) string {
 		token := tokenizer.Token()
 		switch token.Type {
 		case html.TextToken:
-			if noscriptDepth > 0 {
+			if scriptTagDepth > 0 {
 				continue
 			}
 
@@ -60,15 +60,15 @@ func Sanitize(baseURL, input string) string {
 
 					tagStack = append(tagStack, tagName)
 				}
-			} else if tagName == "noscript" {
-				noscriptDepth++
+			} else if isScriptTag(tagName) {
+				scriptTagDepth++
 			}
 		case html.EndTagToken:
 			tagName := token.DataAtom.String()
 			if isValidTag(tagName) && inList(tagName, tagStack) {
 				buffer.WriteString(fmt.Sprintf("</%s>", tagName))
-			} else if tagName == "noscript" {
-				noscriptDepth--
+			} else if isScriptTag(tagName) {
+				scriptTagDepth--
 			}
 		case html.SelfClosingTagToken:
 			tagName := token.DataAtom.String()
@@ -392,4 +392,8 @@ func rewriteIframeURL(link string) string {
 	}
 
 	return link
+}
+
+func isScriptTag(tagName string) bool {
+	return tagName == "script" || tagName == "noscript"
 }

--- a/reader/sanitizer/sanitizer_test.go
+++ b/reader/sanitizer/sanitizer_test.go
@@ -212,3 +212,13 @@ func TestReplaceIframeURL(t *testing.T) {
 		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
 	}
 }
+
+func TestReplaceNoScript(t *testing.T) {
+	input := `<p>Before paragraph.</p><noscript>Inside <code>noscript</code> tag with an image: <img src="http://example.org/" alt="Test"></noscript><p>After paragraph.</p>`
+	expected := `<p>Before paragraph.</p><p>After paragraph.</p>`
+	output := Sanitize("http://example.org/", input)
+
+	if expected != output {
+		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
+	}
+}

--- a/reader/sanitizer/sanitizer_test.go
+++ b/reader/sanitizer/sanitizer_test.go
@@ -222,3 +222,13 @@ func TestReplaceNoScript(t *testing.T) {
 		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
 	}
 }
+
+func TestReplaceScript(t *testing.T) {
+	input := `<p>Before paragraph.</p><script type="text/javascript">alert("1");</script><p>After paragraph.</p>`
+	expected := `<p>Before paragraph.</p><p>After paragraph.</p>`
+	output := Sanitize("http://example.org/", input)
+
+	if expected != output {
+		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)
+	}
+}


### PR DESCRIPTION
Go's x/net/html doesn't handle `noscript` tags well. It assumes the entire contents of any noscript tag is a text node, which is not always the case. There's an [open issue](https://github.com/golang/go/issues/16318) tracking it for two years now but the issue remains.

What I've found is that many sites lazy load images and use noscript as a fall back. Currently the Sanitizer strips noscript but because the subsequent content is returned as a text node it ends up putting HTML in the article. So the article ends up looking like this (with actual HTML code right alongside normal text):

> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ac urna sed purus mollis convallis ac ut libero. Ut quis.
>
> \<div class="lazyload-fallback">
>     \<img src="medium-res.jpg" alt="">
> \</div>
>
> Vestibulum auctor nulla purus, sed ultricies eros fringilla ut. Sed a nisl ante. Integer quis tempor nisl. Nunc.

This PR allows the sanitizer to track `noscript` and filter out its content from the article.

**Update:** Looks like this affects the `script` tag as well. ~~I'll wait to get your response for this PR and if you're good with it make some tweaks to include both script and noscript.~~

**Update 2:** Added support for filtering both `script` and `noscript` tags.