### PR TITLE
Refactor AddImageTitle rewriter.

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -22,9 +22,19 @@ func addImageTitle(entryURL, entryContent string) string {
 		return entryContent
 	}
 
-	imgTag := doc.Find("img").First()
-	if titleAttr, found := imgTag.Attr("title"); found {
-		return entryContent + `<blockquote cite="` + entryURL + `">` + titleAttr + "</blockquote>"
+	matches := doc.Find("img[src][title]")
+
+	if matches.Length() > 0 {
+		matches.Each(func(i int, img *goquery.Selection) {
+			altAttr := img.AttrOr("alt", "")
+			srcAttr, _ := img.Attr("src")
+			titleAttr, _ := img.Attr("title")
+
+			img.ReplaceWithHtml(`<figure><img src="` + srcAttr + `" alt="` + altAttr + `"/><figcaption><p>` + titleAttr + `</p></figcaption></figure>`)
+		})
+
+		output, _ := doc.Find("body").First().Html()
+		return output
 	}
 
 	return entryContent

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -35,7 +35,15 @@ func TestRewriteWithInexistingCustomRule(t *testing.T) {
 func TestRewriteWithXkcdLink(t *testing.T) {
 	description := `<img src="https://imgs.xkcd.com/comics/thermostat.png" title="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`
 	output := Rewriter("https://xkcd.com/1912/", description, ``)
-	expected := description + `<blockquote cite="https://xkcd.com/1912/">Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you.</blockquote>`
+	expected := `<figure><img src="https://imgs.xkcd.com/comics/thermostat.png" alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you."/><figcaption><p>Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you.</p></figcaption></figure>`
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+func TestRewriteWithXkcdLinkAndImageNoTitle(t *testing.T) {
+	description := `<img src="https://imgs.xkcd.com/comics/thermostat.png" alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`
+	output := Rewriter("https://xkcd.com/1912/", description, ``)
+	expected := description
 	if expected != output {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
 	}


### PR DESCRIPTION
* Only processes images with `src` **and** `title` attributes (others are ignored).
* Processes **all** images in the document (not just the first one).
* Wraps the image and its title attribute in a `figure` tag with the title attribute's contents in a `figcaption` tag.

Updated xkcd rewriter unit test.

Added another xkcd rewriter unit test to check rendering of images without title tags.

---

These changes keep the title text with the image where it's found in the document (versus just appending the first image's title text to the end of the document). It works with simple comics like *xkcd* but also with more complicated articles like the *[What If?](https://what-if.xkcd.com)* blog (by the same author; who in his posts uses multiple images, each with their own title text).

`entryContent` is left unaltered if no images with title tags are found.