### PR TITLE
Sandbox iframes when sanitizing.

### DIFF
--- a/reader/sanitizer/sanitizer.go
+++ b/reader/sanitizer/sanitizer.go
@@ -131,15 +131,16 @@ func sanitizeAttributes(baseURL, tagName string, attributes []html.Attribute) ([
 }
 
 func getExtraAttributes(tagName string) ([]string, []string) {
-	if tagName == "a" {
+	switch tagName {
+	case "a":
 		return []string{"rel", "target", "referrerpolicy"}, []string{`rel="noopener noreferrer"`, `target="_blank"`, `referrerpolicy="no-referrer"`}
-	}
-
-	if tagName == "video" || tagName == "audio" {
+	case "video", "audio":
 		return []string{"controls"}, []string{"controls"}
+	case "iframe":
+		return []string{"sandbox"}, []string{`sandbox="allow-scripts allow-same-origin"`}
+	default:
+		return nil, nil
 	}
-
-	return nil, nil
 }
 
 func isValidTag(tagName string) bool {

--- a/reader/sanitizer/sanitizer_test.go
+++ b/reader/sanitizer/sanitizer_test.go
@@ -165,7 +165,7 @@ func TestEspaceAttributes(t *testing.T) {
 
 func TestReplaceYoutubeURL(t *testing.T) {
 	input := `<iframe src="http://www.youtube.com/embed/test123?version=3&#038;rel=1&#038;fs=1&#038;autohide=2&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;wmode=transparent"></iframe>`
-	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent"></iframe>`
+	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent" sandbox="allow-scripts allow-same-origin"></iframe>`
 	output := Sanitize("http://example.org/", input)
 
 	if expected != output {
@@ -175,7 +175,7 @@ func TestReplaceYoutubeURL(t *testing.T) {
 
 func TestReplaceSecureYoutubeURL(t *testing.T) {
 	input := `<iframe src="https://www.youtube.com/embed/test123"></iframe>`
-	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123"></iframe>`
+	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123" sandbox="allow-scripts allow-same-origin"></iframe>`
 	output := Sanitize("http://example.org/", input)
 
 	if expected != output {
@@ -185,7 +185,7 @@ func TestReplaceSecureYoutubeURL(t *testing.T) {
 
 func TestReplaceSecureYoutubeURLWithParameters(t *testing.T) {
 	input := `<iframe src="https://www.youtube.com/embed/test123?rel=0&amp;controls=0"></iframe>`
-	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0"></iframe>`
+	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0" sandbox="allow-scripts allow-same-origin"></iframe>`
 	output := Sanitize("http://example.org/", input)
 
 	if expected != output {
@@ -194,8 +194,8 @@ func TestReplaceSecureYoutubeURLWithParameters(t *testing.T) {
 }
 
 func TestReplaceYoutubeURLAlreadyReplaced(t *testing.T) {
-	input := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0"></iframe>`
-	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0"></iframe>`
+	input := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0" sandbox="allow-scripts allow-same-origin"></iframe>`
+	expected := `<iframe src="https://www.youtube-nocookie.com/embed/test123?rel=0&amp;controls=0" sandbox="allow-scripts allow-same-origin"></iframe>`
 	output := Sanitize("http://example.org/", input)
 
 	if expected != output {
@@ -205,7 +205,7 @@ func TestReplaceYoutubeURLAlreadyReplaced(t *testing.T) {
 
 func TestReplaceIframeURL(t *testing.T) {
 	input := `<iframe src="https://player.vimeo.com/video/123456?title=0&amp;byline=0"></iframe>`
-	expected := `<iframe src="https://player.vimeo.com/video/123456?title=0&amp;byline=0"></iframe>`
+	expected := `<iframe src="https://player.vimeo.com/video/123456?title=0&amp;byline=0" sandbox="allow-scripts allow-same-origin"></iframe>`
 	output := Sanitize("http://example.org/", input)
 
 	if expected != output {


### PR DESCRIPTION
Updated iframe unit tests to expect new `sandbox` attribute where appropriate.

Refactored sanitizer.getExtraAttributes() to use `switch` instead of multiple `if` statements.

---

This change further restricts the access an `iframe` has. Tested this against YouTube, Vimeo and SoundCloud embeds. All seem to work.

I also refactored `getExtraAttributes()` because as the number of checks grows, using a switch seems cleaner and is probably a pinch faster.