### PR TITLE
New `add_dynamic_image` rewriter for JavaScript-loaded images.

### DIFF
--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -24,6 +24,8 @@ func Rewriter(entryURL, entryContent, customRewriteRules string) string {
 		switch strings.TrimSpace(rule) {
 		case "add_image_title":
 			entryContent = addImageTitle(entryURL, entryContent)
+		case "add_dynamic_image":
+			entryContent = addDynamicImage(entryURL, entryContent)
 		case "add_youtube_video":
 			entryContent = addYoutubeVideo(entryURL, entryContent)
 		case "add_pdf_download_link":

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -40,6 +40,7 @@ func TestRewriteWithXkcdLink(t *testing.T) {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
 	}
 }
+
 func TestRewriteWithXkcdLinkAndImageNoTitle(t *testing.T) {
 	description := `<img src="https://imgs.xkcd.com/comics/thermostat.png" alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`
 	output := Rewriter("https://xkcd.com/1912/", description, ``)
@@ -48,6 +49,7 @@ func TestRewriteWithXkcdLinkAndImageNoTitle(t *testing.T) {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
 	}
 }
+
 func TestRewriteWithXkcdLinkAndNoImage(t *testing.T) {
 	description := "test"
 	output := Rewriter("https://xkcd.com/1912/", description, ``)
@@ -71,6 +73,46 @@ func TestRewriteWithPDFLink(t *testing.T) {
 	description := "test"
 	output := Rewriter("https://example.org/document.pdf", description, ``)
 	expected := `<a href="https://example.org/document.pdf">PDF</a><br>test`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestRewriteWithNoLazyImage(t *testing.T) {
+	description := `<img src="https://example.org/image.jpg" alt="Image"><noscript><p>Some text</p></noscript>`
+	output := Rewriter("https://example.org/article", description, "add_dynamic_image")
+	expected := description
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestRewriteWithLazyImage(t *testing.T) {
+	description := `<img src="" data-url="https://example.org/image.jpg" alt="Image"><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`
+	output := Rewriter("https://example.org/article", description, "add_dynamic_image")
+	expected := `<img src="https://example.org/image.jpg" data-url="https://example.org/image.jpg" alt="Image"/><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestRewriteWithLazyDivImage(t *testing.T) {
+	description := `<div data-url="https://example.org/image.jpg" alt="Image"></div><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`
+	output := Rewriter("https://example.org/article", description, "add_dynamic_image")
+	expected := `<img src="https://example.org/image.jpg" alt="Image"/><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestRewriteWithUnknownLazyNoScriptImage(t *testing.T) {
+	description := `<img src="" data-non-candidate="https://example.org/image.jpg" alt="Image"><noscript><img src="https://example.org/fallback.jpg" alt="Fallback"></noscript>`
+	output := Rewriter("https://example.org/article", description, "add_dynamic_image")
+	expected := `<img src="" data-non-candidate="https://example.org/image.jpg" alt="Image"/><img src="https://example.org/fallback.jpg" alt="Fallback"/>`
 
 	if expected != output {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)


### PR DESCRIPTION
Searches image tags for various `data-*` attributes and sets `src` attribute appropriately. Falls back to searching `noscript` for `img` tags.

Includes unit tests.

---

Some web sites use JavaScript to load images only when the image is in the viewport (e.g. when scrolling down the page, images load as that part of the page becomes visible), other sites will load images based on the visitor's screen size (e.g. mobile loads a smaller image than desktop). Scraping sites like this means entries can have no images in them. This rewriter attempts to find the highest quality image and include it.

The `candidateAttrs` values will need to be updated as new sites are reported, etc.

I've been using this code successfully for over a week on an assortment of sites.