### PR TITLE
Make image proxy filter tunable.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ const (
 	defaultCertDomain       = ""
 	defaultCertCache        = "/tmp/cert_cache"
 	defaultCleanupFrequency = 24
-	defaultProxyImages      = 1
+	defaultProxyImages      = "http-only"
 )
 
 // Config manages configuration parameters.
@@ -218,9 +218,9 @@ func (c *Config) PocketConsumerKey(defaultValue string) string {
 	return c.get("POCKET_CONSUMER_KEY", defaultValue)
 }
 
-// ProxyImages returns 0 to never proxy, 1 to proxy non-HTTPS, 2 to always proxy.
-func (c *Config) ProxyImages() int {
-	return c.getInt("PROXY_IMAGES", defaultProxyImages)
+// ProxyImages returns "none" to never proxy, "http-only" to proxy non-HTTPS, "all" to always proxy.
+func (c *Config) ProxyImages() string {
+	return c.get("PROXY_IMAGES", defaultProxyImages)
 }
 
 // NewConfig returns a new Config.

--- a/config/config.go
+++ b/config/config.go
@@ -220,13 +220,7 @@ func (c *Config) PocketConsumerKey(defaultValue string) string {
 
 // ProxyImages returns 0 to never proxy, 1 to proxy non-HTTPS, 2 to always proxy.
 func (c *Config) ProxyImages() int {
-	value := c.getInt("PROXY_IMAGES", defaultProxyImages)
-
-	if value >= 0 && value <= 2 {
-		return value
-	}
-
-	return defaultProxyImages
+	return c.getInt("PROXY_IMAGES", defaultProxyImages)
 }
 
 // NewConfig returns a new Config.

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ const (
 	defaultCertDomain       = ""
 	defaultCertCache        = "/tmp/cert_cache"
 	defaultCleanupFrequency = 24
+	defaultProxyImages      = 1
 )
 
 // Config manages configuration parameters.
@@ -215,6 +216,17 @@ func (c *Config) CreateAdmin() bool {
 // PocketConsumerKey returns the Pocket Consumer Key if defined as environment variable.
 func (c *Config) PocketConsumerKey(defaultValue string) string {
 	return c.get("POCKET_CONSUMER_KEY", defaultValue)
+}
+
+// ProxyImages returns 0 to never proxy, 1 to proxy non-HTTPS, 2 to always proxy.
+func (c *Config) ProxyImages() int {
+	value := c.getInt("PROXY_IMAGES", defaultProxyImages)
+
+	if value >= 0 && value <= 2 {
+		return value
+	}
+
+	return defaultProxyImages
 }
 
 // NewConfig returns a new Config.

--- a/filter/image_proxy_filter.go
+++ b/filter/image_proxy_filter.go
@@ -19,7 +19,7 @@ import (
 // ImageProxyFilter rewrites image tag URLs to local proxy URL (by default only non-HTTPS URLs)
 func ImageProxyFilter(router *mux.Router, cfg *config.Config, data string) string {
 	proxyImages := cfg.ProxyImages()
-	if proxyImages == 0 {
+	if proxyImages == "none" {
 		return data
 	}
 
@@ -30,7 +30,7 @@ func ImageProxyFilter(router *mux.Router, cfg *config.Config, data string) strin
 
 	doc.Find("img").Each(func(i int, img *goquery.Selection) {
 		if srcAttr, ok := img.Attr("src"); ok {
-			if proxyImages == 2 || !url.IsHTTPS(srcAttr) {
+			if proxyImages == "all" || !url.IsHTTPS(srcAttr) {
 				img.SetAttr("src", Proxify(router, srcAttr))
 			}
 		}

--- a/filter/image_proxy_filter_test.go
+++ b/filter/image_proxy_filter_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestProxyFilterWithHttpDefault(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "1")
+	os.Setenv("PROXY_IMAGES", "http-only")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -33,7 +33,7 @@ func TestProxyFilterWithHttpDefault(t *testing.T) {
 
 func TestProxyFilterWithHttpsDefault(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "1")
+	os.Setenv("PROXY_IMAGES", "http-only")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -50,7 +50,7 @@ func TestProxyFilterWithHttpsDefault(t *testing.T) {
 
 func TestProxyFilterWithHttpNever(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "0")
+	os.Setenv("PROXY_IMAGES", "none")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -67,7 +67,7 @@ func TestProxyFilterWithHttpNever(t *testing.T) {
 
 func TestProxyFilterWithHttpsNever(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "0")
+	os.Setenv("PROXY_IMAGES", "none")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -84,7 +84,7 @@ func TestProxyFilterWithHttpsNever(t *testing.T) {
 
 func TestProxyFilterWithHttpAlways(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "2")
+	os.Setenv("PROXY_IMAGES", "all")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -101,7 +101,7 @@ func TestProxyFilterWithHttpAlways(t *testing.T) {
 
 func TestProxyFilterWithHttpsAlways(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "2")
+	os.Setenv("PROXY_IMAGES", "all")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -118,7 +118,7 @@ func TestProxyFilterWithHttpsAlways(t *testing.T) {
 
 func TestProxyFilterWithHttpInvalid(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "9")
+	os.Setenv("PROXY_IMAGES", "invalid")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()
@@ -135,7 +135,7 @@ func TestProxyFilterWithHttpInvalid(t *testing.T) {
 
 func TestProxyFilterWithHttpsInvalid(t *testing.T) {
 	os.Clearenv()
-	os.Setenv("PROXY_IMAGES", "9")
+	os.Setenv("PROXY_IMAGES", "invalid")
 	c := config.NewConfig()
 
 	r := mux.NewRouter()

--- a/filter/image_proxy_filter_test.go
+++ b/filter/image_proxy_filter_test.go
@@ -6,17 +6,24 @@ package filter
 
 import (
 	"net/http"
+	"os"
 	"testing"
+
+	"github.com/miniflux/miniflux/config"
 
 	"github.com/gorilla/mux"
 )
 
-func TestProxyFilterWithHttp(t *testing.T) {
+func TestProxyFilterWithHttpDefault(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "1")
+	c := config.NewConfig()
+
 	r := mux.NewRouter()
 	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
 
 	input := `<p><img src="http://website/folder/image.png" alt="Test"/></p>`
-	output := ImageProxyFilter(r, input)
+	output := ImageProxyFilter(r, c, input)
 	expected := `<p><img src="/proxy/aHR0cDovL3dlYnNpdGUvZm9sZGVyL2ltYWdlLnBuZw==" alt="Test"/></p>`
 
 	if expected != output {
@@ -24,13 +31,85 @@ func TestProxyFilterWithHttp(t *testing.T) {
 	}
 }
 
-func TestProxyFilterWithHttps(t *testing.T) {
+func TestProxyFilterWithHttpsDefault(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "1")
+	c := config.NewConfig()
+
 	r := mux.NewRouter()
 	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
 
 	input := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
-	output := ImageProxyFilter(r, input)
+	output := ImageProxyFilter(r, c, input)
 	expected := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestProxyFilterWithHttpNever(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "0")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="http://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := input
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestProxyFilterWithHttpsNever(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "0")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := input
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestProxyFilterWithHttpAlways(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "2")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="http://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := `<p><img src="/proxy/aHR0cDovL3dlYnNpdGUvZm9sZGVyL2ltYWdlLnBuZw==" alt="Test"/></p>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestProxyFilterWithHttpsAlways(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "2")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := `<p><img src="/proxy/aHR0cHM6Ly93ZWJzaXRlL2ZvbGRlci9pbWFnZS5wbmc=" alt="Test"/></p>`
 
 	if expected != output {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)

--- a/filter/image_proxy_filter_test.go
+++ b/filter/image_proxy_filter_test.go
@@ -115,3 +115,37 @@ func TestProxyFilterWithHttpsAlways(t *testing.T) {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
 	}
 }
+
+func TestProxyFilterWithHttpInvalid(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "9")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="http://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := `<p><img src="/proxy/aHR0cDovL3dlYnNpdGUvZm9sZGVyL2ltYWdlLnBuZw==" alt="Test"/></p>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
+func TestProxyFilterWithHttpsInvalid(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("PROXY_IMAGES", "9")
+	c := config.NewConfig()
+
+	r := mux.NewRouter()
+	r.HandleFunc("/proxy/{encodedURL}", func(w http.ResponseWriter, r *http.Request) {}).Name("proxy")
+
+	input := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
+	output := ImageProxyFilter(r, c, input)
+	expected := `<p><img src="https://website/folder/image.png" alt="Test"/></p>`
+
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}

--- a/template/functions.go
+++ b/template/functions.go
@@ -51,11 +51,11 @@ func (f *funcMap) Map() template.FuncMap {
 		"proxyURL": func(link string) string {
 			proxyImages := f.cfg.ProxyImages()
 
-			if proxyImages == 0 || (proxyImages == 1 && url.IsHTTPS(link)) {
-				return link
+			if proxyImages == 2 || (proxyImages != 0 && !url.IsHTTPS(link)) {
+				return filter.Proxify(f.router, link)
 			}
 
-			return filter.Proxify(f.router, link)
+			return link
 		},
 		"domain": func(websiteURL string) string {
 			return url.Domain(websiteURL)

--- a/template/functions.go
+++ b/template/functions.go
@@ -46,10 +46,12 @@ func (f *funcMap) Map() template.FuncMap {
 			return template.HTML(str)
 		},
 		"proxyFilter": func(data string) string {
-			return filter.ImageProxyFilter(f.router, data)
+			return filter.ImageProxyFilter(f.router, f.cfg, data)
 		},
 		"proxyURL": func(link string) string {
-			if url.IsHTTPS(link) {
+			proxyImages := f.cfg.ProxyImages()
+
+			if proxyImages == 0 || (proxyImages == 1 && url.IsHTTPS(link)) {
 				return link
 			}
 

--- a/template/functions.go
+++ b/template/functions.go
@@ -51,7 +51,7 @@ func (f *funcMap) Map() template.FuncMap {
 		"proxyURL": func(link string) string {
 			proxyImages := f.cfg.ProxyImages()
 
-			if proxyImages == 2 || (proxyImages != 0 && !url.IsHTTPS(link)) {
+			if proxyImages == "all" || (proxyImages != "none" && !url.IsHTTPS(link)) {
 				return filter.Proxify(f.router, link)
 			}
 


### PR DESCRIPTION
Adds `PROXY_IMAGES` configuration setting to change image proxy filter behaviour:

* `0` = Never proxy.
* `1` = Proxy non-HTTPS (default).
* `2` = Always proxy.

Added additional unit tests.

Addresses #142.

---

If accepted, I'll do a PR for the documentation.