### PR TITLE
Support for 'published' tag in atom feed

### DIFF
--- a/reader/atom/atom.go
+++ b/reader/atom/atom.go
@@ -30,6 +30,7 @@ type atomFeed struct {
 type atomEntry struct {
 	ID         string         `xml:"id"`
 	Title      atomContent    `xml:"title"`
+	Published  string         `xml:"published"`
 	Updated    string         `xml:"updated"`
 	Links      []atomLink     `xml:"link"`
 	Summary    string         `xml:"summary"`
@@ -128,8 +129,13 @@ func getRelationURL(links []atomLink, relation string) string {
 }
 
 func getDate(a *atomEntry) time.Time {
-	if a.Updated != "" {
-		result, err := date.Parse(a.Updated)
+	dateText := a.Updated
+	if dateText == "" {
+		dateText = a.Published
+	}
+
+	if dateText != "" {
+		result, err := date.Parse(dateText)
 		if err != nil {
 			logger.Error("atom: %v", err)
 			return time.Now()

--- a/reader/atom/parser_test.go
+++ b/reader/atom/parser_test.go
@@ -422,6 +422,57 @@ func TestParseEntryWithEnclosures(t *testing.T) {
 	}
 }
 
+func TestParseEntryWithPublished(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<feed xmlns="http://www.w3.org/2005/Atom">
+	  <title>Example Feed</title>
+	  <link href="http://example.org/"/>
+
+	  <entry>
+		<link href="http://example.org/2003/12/13/atom03"/>
+		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+		<published>2003-12-13T18:30:02Z</published>
+		<summary>Some text.</summary>
+	  </entry>
+
+	</feed>`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !feed.Entries[0].Date.Equal(time.Date(2003, time.December, 13, 18, 30, 2, 0, time.UTC)) {
+		t.Errorf("Incorrect entry date, got: %v", feed.Entries[0].Date)
+	}
+}
+
+func TestParseEntryWithPublishedAndUpdated(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+	<feed xmlns="http://www.w3.org/2005/Atom">
+	  <title>Example Feed</title>
+	  <link href="http://example.org/"/>
+
+	  <entry>
+		<link href="http://example.org/2003/12/13/atom03"/>
+		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+		<published>2002-11-12T18:30:02Z</published>
+		<updated>2003-12-13T18:30:02Z</updated>
+		<summary>Some text.</summary>
+	  </entry>
+
+	</feed>`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !feed.Entries[0].Date.Equal(time.Date(2003, time.December, 13, 18, 30, 2, 0, time.UTC)) {
+		t.Errorf("Incorrect entry date, got: %v", feed.Entries[0].Date)
+	}
+}
+
 func TestParseInvalidXml(t *testing.T) {
 	data := `garbage`
 	_, err := Parse(bytes.NewBufferString(data))


### PR DESCRIPTION
There are atom feeds which use 'published' tag in entry instead of 'updated'. As described [here](https://validator.w3.org/feed/docs/atom.html) 'published' is optional element. It could be used when 'updated' tag is not present for entry.