### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: miniflux


### PR DESCRIPTION
Allows to git push to heroku/self-hosted alternatives easily.

I personally use [dokku](https://github.com/dokku/dokku) which works the same way as heroku: it detects the type of project, downloads the proper Docker image, does what's required (compiling in Go's case) and starts the app based on what's in the Procfile. Adding the Procfile directly in this repos allows anyone to do:

```console
$ # create the app on the server; using dokku: `dokku apps:create rss`
$ # create the database container on the server; using dokku: `dokku postgres:create rss-db`
$ # link them; using dokku: `dokku postgres:link rss-db rss`
$ git clone https://github.com/miniflux/miniflux
$ cd miniflux
$ git remote add dokku dokku@dokku.me:rss
$ git push dokku 2.0.10
```

My example uses Dokku but it's really similar with heroku.