### PR TITLE
Hide pagination entirely when not applicable

### DIFF
--- a/template/common.go
+++ b/template/common.go
@@ -219,6 +219,7 @@ var templateCommonMap = map[string]string{
 {{ end }}
 `,
 	"pagination": `{{ define "pagination" }}
+{{ if .Show }}
 <div class="pagination">
     {{ if .ShowPrev }}
     <div class="pagination-prev">
@@ -233,6 +234,7 @@ var templateCommonMap = map[string]string{
     {{ end }}
 </div>
 {{ end }}
+{{ end }}
 `,
 }
 
@@ -240,5 +242,5 @@ var templateCommonMapChecksums = map[string]string{
 	"entry_pagination": "756ef122f3ebc73754b5fc4304bf05e59da0ab4af030b2509ff4c9b4a74096ce",
 	"item_meta":        "d85d1ae181120b7a3d38173b3990a0c2a5cf706cabdfb00c4d002a09271de51e",
 	"layout":           "2491695e33a496c9bd902a2cb5bc3a6a540f98ac7c24591d503a77ba0f5f0ebe",
-	"pagination":       "23c0b481d9ea6c534d45133fa7a6c84a14cdfeb04b67735f7ba46c26d6735a30",
+	"pagination":       "3c7581392268f73adb099dac5257fbbfca3aa26981400f001cdfd8a6f72f0137",
 }

--- a/template/common.go
+++ b/template/common.go
@@ -220,21 +220,17 @@ var templateCommonMap = map[string]string{
 `,
 	"pagination": `{{ define "pagination" }}
 <div class="pagination">
+    {{ if .ShowPrev }}
     <div class="pagination-prev">
-        {{ if .ShowPrev }}
             <a href="{{ .Route }}{{ if gt .PrevOffset 0 }}?offset={{ .PrevOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}{{ else }}{{ if .SearchQuery }}?q={{ .SearchQuery }}{{ end }}{{ end }}" data-page="previous">{{ t "Previous" }}</a>
-        {{ else }}
-            {{ t "Previous" }}
-        {{ end }}
     </div>
+    {{ end }}
 
+    {{ if .ShowNext }}
     <div class="pagination-next">
-        {{ if .ShowNext }}
             <a href="{{ .Route }}?offset={{ .NextOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}" data-page="next">{{ t "Next" }}</a>
-        {{ else }}
-            {{ t "Next" }}
-        {{ end }}
     </div>
+    {{ end }}
 </div>
 {{ end }}
 `,
@@ -244,5 +240,5 @@ var templateCommonMapChecksums = map[string]string{
 	"entry_pagination": "756ef122f3ebc73754b5fc4304bf05e59da0ab4af030b2509ff4c9b4a74096ce",
 	"item_meta":        "d85d1ae181120b7a3d38173b3990a0c2a5cf706cabdfb00c4d002a09271de51e",
 	"layout":           "2491695e33a496c9bd902a2cb5bc3a6a540f98ac7c24591d503a77ba0f5f0ebe",
-	"pagination":       "b592d58ea9d6abf2dc0b158621404cbfaeea5413b1c8b8b9818725963096b196",
+	"pagination":       "23c0b481d9ea6c534d45133fa7a6c84a14cdfeb04b67735f7ba46c26d6735a30",
 }

--- a/template/html/common/pagination.html
+++ b/template/html/common/pagination.html
@@ -1,4 +1,5 @@
 {{ define "pagination" }}
+{{ if .Show }}
 <div class="pagination">
     {{ if .ShowPrev }}
     <div class="pagination-prev">
@@ -12,4 +13,5 @@
     </div>
     {{ end }}
 </div>
+{{ end }}
 {{ end }}

--- a/template/html/common/pagination.html
+++ b/template/html/common/pagination.html
@@ -1,19 +1,15 @@
 {{ define "pagination" }}
 <div class="pagination">
+    {{ if .ShowPrev }}
     <div class="pagination-prev">
-        {{ if .ShowPrev }}
             <a href="{{ .Route }}{{ if gt .PrevOffset 0 }}?offset={{ .PrevOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}{{ else }}{{ if .SearchQuery }}?q={{ .SearchQuery }}{{ end }}{{ end }}" data-page="previous">{{ t "Previous" }}</a>
-        {{ else }}
-            {{ t "Previous" }}
-        {{ end }}
     </div>
+    {{ end }}
 
+    {{ if .ShowNext }}
     <div class="pagination-next">
-        {{ if .ShowNext }}
             <a href="{{ .Route }}?offset={{ .NextOffset }}{{ if .SearchQuery }}&amp;q={{ .SearchQuery }}{{ end }}" data-page="next">{{ t "Next" }}</a>
-        {{ else }}
-            {{ t "Next" }}
-        {{ end }}
     </div>
+    {{ end }}
 </div>
 {{ end }}

--- a/ui/pagination.go
+++ b/ui/pagination.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-package ui  // import "miniflux.app/ui"
+package ui // import "miniflux.app/ui"
 
 const (
 	nbItemsPerPage = 100
@@ -13,6 +13,7 @@ type pagination struct {
 	Total        int
 	Offset       int
 	ItemsPerPage int
+	Show         bool
 	ShowNext     bool
 	ShowPrev     bool
 	NextOffset   int
@@ -25,6 +26,7 @@ func (c *Controller) getPagination(route string, total, offset int) pagination {
 	prevOffset := 0
 	showNext := (total - offset) > nbItemsPerPage
 	showPrev := offset > 0
+	show := showNext || showPrev
 
 	if showNext {
 		nextOffset = offset + nbItemsPerPage
@@ -39,6 +41,7 @@ func (c *Controller) getPagination(route string, total, offset int) pagination {
 		Total:        total,
 		Offset:       offset,
 		ItemsPerPage: nbItemsPerPage,
+		Show:         show,
 		ShowNext:     showNext,
 		NextOffset:   nextOffset,
 		ShowPrev:     showPrev,


### PR DESCRIPTION
I find it confusing to see pagination links when there are not actually
any more pages of entries available. Hiding them entirely makes the
experience more intuitive.