### PR TITLE
Avoid line break between emoji and (un)read/(un)star links

### DIFF
--- a/template/html/common/item_meta.html
+++ b/template/html/common/item_meta.html
@@ -34,7 +34,7 @@
                 data-label-star="☆ {{ t "Star" }}"
                 data-label-unstar="★ {{ t "Unstar" }}"
                 data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
         </li>
         <li>
             <a href="#"
@@ -43,7 +43,7 @@
                 data-label-read="✔&#xfe0e; {{ t "Read" }}"
                 data-label-unread="✘ {{ t "Unread" }}"
                 data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e;&nbsp;{{ t "Read" }}{{ end }}</a>
         </li>
     </ul>
 </div>

--- a/template/html/entry.html
+++ b/template/html/entry.html
@@ -15,7 +15,7 @@
                         data-label-read="✔&#xfe0e; {{ t "Read" }}"
                         data-label-unread="✘ {{ t "Unread" }}"
                         data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                        >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                        >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
                 </li>
                 <li>
                     <a href="#"
@@ -25,7 +25,7 @@
                         data-label-star="☆ {{ t "Star" }}"
                         data-label-unstar="★ {{ t "Unstar" }}"
                         data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                        >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                        >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
                 </li>
                 {{ if .hasSaveEntry }}
                     <li>


### PR DESCRIPTION
Sometimes when reading on mobile, the Star/Read links jump to a new line. By using a non-breaking space, the emoji and the text will be kept together.

Before:
![miniflux-before](https://user-images.githubusercontent.com/3284058/45505439-ec25ba00-b78c-11e8-909a-d4aa37bf0b4c.png)

After:
![image](https://user-images.githubusercontent.com/3284058/45505664-6f471000-b78d-11e8-8673-cbd543304ad1.png)