### PR TITLE
Avoid line break between emoji and (un)read/(un)star links

### DIFF
--- a/template/common.go
+++ b/template/common.go
@@ -55,19 +55,19 @@ var templateCommonMap = map[string]string{
                 data-toggle-bookmark="true"
                 data-bookmark-url="{{ route "toggleBookmark" "entryID" .entry.ID }}"
                 data-label-loading="{{ t "Saving..." }}"
-                data-label-star="☆ {{ t "Star" }}"
-                data-label-unstar="★ {{ t "Unstar" }}"
+                data-label-star="☆&nbsp;{{ t "Star" }}"
+                data-label-unstar="★&nbsp;{{ t "Unstar" }}"
                 data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
         </li>
         <li>
             <a href="#"
                 title="{{ t "Change entry status" }}"
                 data-toggle-status="true"
-                data-label-read="✔&#xfe0e; {{ t "Read" }}"
-                data-label-unread="✘ {{ t "Unread" }}"
+                data-label-read="✔&#xfe0e;&nbsp;{{ t "Read" }}"
+                data-label-unread="✘&nbsp;{{ t "Unread" }}"
                 data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e;&nbsp;{{ t "Read" }}{{ end }}</a>
         </li>
     </ul>
 </div>
@@ -242,7 +242,7 @@ var templateCommonMap = map[string]string{
 
 var templateCommonMapChecksums = map[string]string{
 	"entry_pagination": "756ef122f3ebc73754b5fc4304bf05e59da0ab4af030b2509ff4c9b4a74096ce",
-	"item_meta":        "d85d1ae181120b7a3d38173b3990a0c2a5cf706cabdfb00c4d002a09271de51e",
+	"item_meta":        "d7459aa616b15095eadf382299a62e46c33b63ac214cbe15bab20156b7f9ed43",
 	"layout":           "2491695e33a496c9bd902a2cb5bc3a6a540f98ac7c24591d503a77ba0f5f0ebe",
 	"pagination":       "b592d58ea9d6abf2dc0b158621404cbfaeea5413b1c8b8b9818725963096b196",
 }

--- a/template/html/common/item_meta.html
+++ b/template/html/common/item_meta.html
@@ -31,19 +31,19 @@
                 data-toggle-bookmark="true"
                 data-bookmark-url="{{ route "toggleBookmark" "entryID" .entry.ID }}"
                 data-label-loading="{{ t "Saving..." }}"
-                data-label-star="☆ {{ t "Star" }}"
-                data-label-unstar="★ {{ t "Unstar" }}"
+                data-label-star="☆&nbsp;{{ t "Star" }}"
+                data-label-unstar="★&nbsp;{{ t "Unstar" }}"
                 data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
         </li>
         <li>
             <a href="#"
                 title="{{ t "Change entry status" }}"
                 data-toggle-status="true"
-                data-label-read="✔&#xfe0e; {{ t "Read" }}"
-                data-label-unread="✘ {{ t "Unread" }}"
+                data-label-read="✔&#xfe0e;&nbsp;{{ t "Read" }}"
+                data-label-unread="✘&nbsp;{{ t "Unread" }}"
                 data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e;&nbsp;{{ t "Read" }}{{ end }}</a>
         </li>
     </ul>
 </div>

--- a/template/html/entry.html
+++ b/template/html/entry.html
@@ -12,20 +12,20 @@
                     <a href="#"
                         title="{{ t "Change entry status" }}"
                         data-toggle-status="true"
-                        data-label-read="✔&#xfe0e; {{ t "Read" }}"
-                        data-label-unread="✘ {{ t "Unread" }}"
+                        data-label-read="✔&#xfe0e;&nbsp;{{ t "Read" }}"
+                        data-label-unread="✘&nbsp;{{ t "Unread" }}"
                         data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                        >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                        >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e;&nbsp;{{ t "Read" }}{{ end }}</a>
                 </li>
                 <li>
                     <a href="#"
                         data-toggle-bookmark="true"
                         data-bookmark-url="{{ route "toggleBookmark" "entryID" .entry.ID }}"
                         data-label-loading="{{ t "Saving..." }}"
-                        data-label-star="☆ {{ t "Star" }}"
-                        data-label-unstar="★ {{ t "Unstar" }}"
+                        data-label-star="☆&nbsp;{{ t "Star" }}"
+                        data-label-unstar="★&nbsp;{{ t "Unstar" }}"
                         data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                        >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                        >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
                 </li>
                 {{ if .hasSaveEntry }}
                     <li>

--- a/template/views.go
+++ b/template/views.go
@@ -559,20 +559,20 @@ var templateViewsMap = map[string]string{
                     <a href="#"
                         title="{{ t "Change entry status" }}"
                         data-toggle-status="true"
-                        data-label-read="✔&#xfe0e; {{ t "Read" }}"
-                        data-label-unread="✘ {{ t "Unread" }}"
+                        data-label-read="✔&#xfe0e;&nbsp;{{ t "Read" }}"
+                        data-label-unread="✘&nbsp;{{ t "Unread" }}"
                         data-value="{{ if eq .entry.Status "read" }}read{{ else }}unread{{ end }}"
-                        >{{ if eq .entry.Status "read" }}✘ {{ t "Unread" }}{{ else }}✔&#xfe0e; {{ t "Read" }}{{ end }}</a>
+                        >{{ if eq .entry.Status "read" }}✘&nbsp;{{ t "Unread" }}{{ else }}✔&#xfe0e;&nbsp;{{ t "Read" }}{{ end }}</a>
                 </li>
                 <li>
                     <a href="#"
                         data-toggle-bookmark="true"
                         data-bookmark-url="{{ route "toggleBookmark" "entryID" .entry.ID }}"
                         data-label-loading="{{ t "Saving..." }}"
-                        data-label-star="☆ {{ t "Star" }}"
-                        data-label-unstar="★ {{ t "Unstar" }}"
+                        data-label-star="☆&nbsp;{{ t "Star" }}"
+                        data-label-unstar="★&nbsp;{{ t "Unstar" }}"
                         data-value="{{ if .entry.Starred }}star{{ else }}unstar{{ end }}"
-                        >{{ if .entry.Starred }}★ {{ t "Unstar" }}{{ else }}☆ {{ t "Star" }}{{ end }}</a>
+                        >{{ if .entry.Starred }}★&nbsp;{{ t "Unstar" }}{{ else }}☆&nbsp;{{ t "Star" }}{{ end }}</a>
                 </li>
                 {{ if .hasSaveEntry }}
                     <li>
@@ -1369,7 +1369,7 @@ var templateViewsMapChecksums = map[string]string{
 	"edit_category":       "cee720faadcec58289b707ad30af623d2ee66c1ce23a732965463250d7ff41c5",
 	"edit_feed":           "1a8e342e4fac80e8b9c73537c7fe8aaf7f9e3e7af22f411927010897dd37e9c3",
 	"edit_user":           "7373e09f805e6c017167001519b9feb04226be6c81c2875cbacd5ce94f2c24bf",
-	"entry":               "1aa2767a879591f0a3681787fc9e2c53e06949695b21106286d190712a9f428a",
+	"entry":               "82a0a4e715da94b12370b380072f1175c9f0e07b37e7f54a9adca4ed1fe015c0",
 	"feed_entries":        "bebc42317ca9e908fcdb98cc1c4a2dc3f4bb7ef6d4c288d3d3fba8f8339403b6",
 	"feeds":               "1006698abfe0962b656f27794bc44568515392da72b6fac0c03316de06024237",
 	"history_entries":     "f94e15d37d7604500cede7b583e03bf79c06be81c6597a4a43693f5712af2e13",


### PR DESCRIPTION
Sometimes when reading on mobile, the Star/Read links jump to a new line, thus making it hard to touch those links with my fat fingers. By using a non-breaking space, the emoji and the text will be kept together.

Before:
![miniflux-before](https://user-images.githubusercontent.com/3284058/45505439-ec25ba00-b78c-11e8-909a-d4aa37bf0b4c.png)

After:
![image](https://user-images.githubusercontent.com/3284058/45505664-6f471000-b78d-11e8-8673-cbd543304ad1.png)