### PR TITLE
Improve time since post date displays.

### DIFF
--- a/template/functions.go
+++ b/template/functions.go
@@ -162,16 +162,16 @@ func elapsedTime(printer *locale.Printer, tz string, t time.Time) string {
 		return printer.Plural("time_elapsed.hours", hours, hours)
 	case d == 1:
 		return printer.Printf("time_elapsed.yesterday")
-	case d < 7:
+	case d < 21:
 		return printer.Plural("time_elapsed.days", d, d)
 	case d < 31:
-		weeks := int(math.Ceil(float64(d) / 7))
+		weeks := int(math.Round(float64(d) / 7))
 		return printer.Plural("time_elapsed.weeks", weeks, weeks)
 	case d < 365:
-		months := int(math.Ceil(float64(d) / 30))
+		months := int(math.Round(float64(d) / 30))
 		return printer.Plural("time_elapsed.months", months, months)
 	default:
-		years := int(math.Ceil(float64(d) / 365))
+		years := int(math.Round(float64(d) / 365))
 		return printer.Plural("time_elapsed.years", years, years)
 	}
 }

--- a/template/functions_test.go
+++ b/template/functions_test.go
@@ -111,7 +111,7 @@ func TestElapsedTime(t *testing.T) {
 		{time.Now().Add(-time.Hour * 3), printer.Plural("time_elapsed.hours", 3, 3)},
 		{time.Now().Add(-time.Hour * 32), printer.Printf("time_elapsed.yesterday")},
 		{time.Now().Add(-time.Hour * 24 * 3), printer.Plural("time_elapsed.days", 3, 3)},
-		{time.Now().Add(-time.Hour * 24 * 14), printer.Plural("time_elapsed.weeks", 2, 2)},
+		{time.Now().Add(-time.Hour * 24 * 14), printer.Plural("time_elapsed.days", 14, 14)},
 		{time.Now().Add(-time.Hour * 24 * 60), printer.Plural("time_elapsed.months", 2, 2)},
 		{time.Now().Add(-time.Hour * 24 * 365 * 3), printer.Plural("time_elapsed.years", 3, 3)},
 	}


### PR DESCRIPTION
- 15 days now is "15 days" rather than "3 weeks" ago.
- 32 days is now "1 month" rather than "2 months" ago.
- 366 days is now "1 year" rather than "2 years" ago.

Closes #267