### PR TITLE
Update entry_scraper.go to fix #284

### DIFF
--- a/ui/entry_scraper.go
+++ b/ui/entry_scraper.go
@@ -36,6 +36,8 @@ func (h *handler) fetchContent(w http.ResponseWriter, r *http.Request) {
 		json.ServerError(w, r, err)
 		return
 	}
+	
+	content = rewrite.Rewriter(entry.URL, content, entry.Feed.RewriteRules)
 
 	entry.Content = sanitizer.Sanitize(entry.URL, content)
 	h.store.UpdateEntryContent(entry)

--- a/ui/entry_scraper.go
+++ b/ui/entry_scraper.go
@@ -6,10 +6,10 @@ package ui // import "miniflux.app/ui"
 
 import (
 	"net/http"
-
 	"miniflux.app/http/request"
 	"miniflux.app/http/response/json"
 	"miniflux.app/model"
+	"miniflux.app/reader/rewrite"
 	"miniflux.app/reader/sanitizer"
 	"miniflux.app/reader/scraper"
 )


### PR DESCRIPTION
I haven't test the code and it's my first try in Golang. :)

It applies Rewriter rules on manual "Fetch Original Content", as done in https://github.com/miniflux/miniflux/blob/master/reader/filter/filter.go

(By the way, shouldn't there be a wrapper that calls scrapper, rewriter and sanitizer at once?)