### PR TITLE
Allow users to disable auto-remove

### DIFF
--- a/storage/entry.go
+++ b/storage/entry.go
@@ -188,6 +188,9 @@ func (s *Storage) UpdateEntries(userID, feedID int64, entries model.Entries, upd
 
 // ArchiveEntries changes the status of read items to "removed" after specified days.
 func (s *Storage) ArchiveEntries(days int) error {
+	if days < 0 {
+		return nil
+	}
 	query := fmt.Sprintf(`
 			UPDATE entries SET status='removed'
 			WHERE id=ANY(SELECT id FROM entries WHERE status='read' AND starred is false AND published_at < now () - '%d days'::interval LIMIT 5000)


### PR DESCRIPTION
I have plenty of space on my VPS, and was surprised when I suddenly could not find the article I read yesterday. Now ARCHIVE_READ_DAYS="-1" disables the auto-remove feature.

I don't know how to test this properly, but it should work.