### PR TITLE
Accept HTML entities when parsing XML

### DIFF
--- a/reader/atom/parser.go
+++ b/reader/atom/parser.go
@@ -17,6 +17,7 @@ import (
 func Parse(data io.Reader) (*model.Feed, *errors.LocalizedError) {
 	atomFeed := new(atomFeed)
 	decoder := xml.NewDecoder(data)
+	decoder.Entity = xml.HTMLEntity
 	decoder.CharsetReader = encoding.CharsetReader
 
 	err := decoder.Decode(atomFeed)

--- a/reader/opml/parser.go
+++ b/reader/opml/parser.go
@@ -16,6 +16,7 @@ import (
 func Parse(data io.Reader) (SubcriptionList, *errors.LocalizedError) {
 	feeds := new(opml)
 	decoder := xml.NewDecoder(data)
+	decoder.Entity = xml.HTMLEntity
 	decoder.CharsetReader = encoding.CharsetReader
 
 	err := decoder.Decode(feeds)

--- a/reader/parser/format.go
+++ b/reader/parser/format.go
@@ -27,6 +27,7 @@ func DetectFeedFormat(data string) string {
 	}
 
 	decoder := xml.NewDecoder(strings.NewReader(data))
+	decoder.Entity = xml.HTMLEntity
 	decoder.CharsetReader = encoding.CharsetReader
 
 	for {

--- a/reader/rdf/parser.go
+++ b/reader/rdf/parser.go
@@ -17,6 +17,7 @@ import (
 func Parse(data io.Reader) (*model.Feed, *errors.LocalizedError) {
 	feed := new(rdfFeed)
 	decoder := xml.NewDecoder(data)
+	decoder.Entity = xml.HTMLEntity
 	decoder.CharsetReader = encoding.CharsetReader
 
 	err := decoder.Decode(feed)

--- a/reader/rss/parser.go
+++ b/reader/rss/parser.go
@@ -17,6 +17,7 @@ import (
 func Parse(data io.Reader) (*model.Feed, *errors.LocalizedError) {
 	feed := new(rssFeed)
 	decoder := xml.NewDecoder(data)
+	decoder.Entity = xml.HTMLEntity
 	decoder.CharsetReader = encoding.CharsetReader
 
 	err := decoder.Decode(feed)


### PR DESCRIPTION
Every once in a while, one of my feeds would throw an XML parse error because it used `&nbsp;` or some other HTML entity. I feel Miniflux should be lenient here, and Go already has a handy hook to make this work.