### PR TITLE
addImageTitle: Fix HTML injection

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -6,6 +6,7 @@ package rewrite // import "miniflux.app/reader/rewrite"
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 
@@ -32,7 +33,7 @@ func addImageTitle(entryURL, entryContent string) string {
 			srcAttr, _ := img.Attr("src")
 			titleAttr, _ := img.Attr("title")
 
-			img.ReplaceWithHtml(`<figure><img src="` + srcAttr + `" alt="` + altAttr + `"/><figcaption><p>` + titleAttr + `</p></figcaption></figure>`)
+			img.ReplaceWithHtml(`<figure><img src="` + srcAttr + `" alt="` + altAttr + `"/><figcaption><p>` + html.EscapeString(titleAttr) + `</p></figcaption></figure>`)
 		})
 
 		output, _ := doc.Find("body").First().Html()

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -61,6 +61,15 @@ func TestRewriteWithXkcdLink(t *testing.T) {
 	}
 }
 
+func TestRewriteWithXkcdLinkHtmlInjection(t *testing.T) {
+	description := `<img src="https://imgs.xkcd.com/comics/thermostat.png" title="<foo>" alt="<foo>" />`
+	output := Rewriter("https://xkcd.com/1912/", description, ``)
+	expected := `<figure><img src="https://imgs.xkcd.com/comics/thermostat.png" alt="&lt;foo&gt;"/><figcaption><p>&lt;foo&gt;</p></figcaption></figure>`
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
 func TestRewriteWithXkcdLinkAndImageNoTitle(t *testing.T) {
 	description := `<img src="https://imgs.xkcd.com/comics/thermostat.png" alt="Your problem is so terrible, I worry that, if I help you, I risk drawing the attention of whatever god of technology inflicted it on you." />`
 	output := Rewriter("https://xkcd.com/1912/", description, ``)


### PR DESCRIPTION
This rewrite rule would change this:

    <img title="<foo>">

to this:

    <figure><img><figcaption><foo></figcaption></figure>

The image title needs to be properly escaped.