### PR TITLE
add_mailto_subject: New rewrite function

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -7,6 +7,7 @@ package rewrite // import "miniflux.app/reader/rewrite"
 import (
 	"fmt"
 	"html"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -34,6 +35,38 @@ func addImageTitle(entryURL, entryContent string) string {
 			titleAttr, _ := img.Attr("title")
 
 			img.ReplaceWithHtml(`<figure><img src="` + srcAttr + `" alt="` + altAttr + `"/><figcaption><p>` + html.EscapeString(titleAttr) + `</p></figcaption></figure>`)
+		})
+
+		output, _ := doc.Find("body").First().Html()
+		return output
+	}
+
+	return entryContent
+}
+
+func addMailtoSubject(entryURL, entryContent string) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(entryContent))
+	if err != nil {
+		return entryContent
+	}
+
+	matches := doc.Find(`a[href^="mailto:"]`)
+
+	if matches.Length() > 0 {
+		matches.Each(func(i int, a *goquery.Selection) {
+			hrefAttr, _ := a.Attr("href")
+
+			mailto, err := url.Parse(hrefAttr)
+			if err != nil {
+				return
+			}
+
+			subject := mailto.Query().Get("subject")
+			if subject == "" {
+				return
+			}
+
+			a.AppendHtml(" [" + html.EscapeString(subject) + "]")
 		})
 
 		output, _ := doc.Find("body").First().Html()

--- a/reader/rewrite/rewriter.go
+++ b/reader/rewrite/rewriter.go
@@ -27,6 +27,8 @@ func Rewriter(entryURL, entryContent, customRewriteRules string) string {
 		switch strings.TrimSpace(rule) {
 		case "add_image_title":
 			entryContent = addImageTitle(entryURL, entryContent)
+		case "add_mailto_subject":
+			entryContent = addMailtoSubject(entryURL, entryContent)
 		case "add_dynamic_image":
 			entryContent = addDynamicImage(entryURL, entryContent)
 		case "add_youtube_video":

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -98,6 +98,15 @@ func TestRewriteWithXkcdAndNoImage(t *testing.T) {
 	}
 }
 
+func TestRewriteMailtoLink(t *testing.T) {
+	description := `<a href="mailto:ryan@qwantz.com?subject=blah%20blah">contact</a>`
+	output := Rewriter("https://www.qwantz.com/", description, ``)
+	expected := `<a href="mailto:ryan@qwantz.com?subject=blah%20blah">contact [blah blah]</a>`
+	if expected != output {
+		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)
+	}
+}
+
 func TestRewriteWithPDFLink(t *testing.T) {
 	description := "test"
 	output := Rewriter("https://example.org/document.pdf", description, ``)

--- a/reader/rewrite/rules.go
+++ b/reader/rewrite/rules.go
@@ -22,6 +22,7 @@ var predefinedRules = map[string]string{
 	"oglaf.com":              "add_image_title",
 	"optipess.com":           "add_image_title",
 	"peebleslab.com":         "add_image_title",
+	"www.qwantz.com":         "add_image_title,add_mailto_subject",
 	"sentfromthemoon.com":    "add_image_title",
 	"thedoghousediaries.com": "add_image_title",
 	"treelobsters.com":       "add_image_title",


### PR DESCRIPTION
Dinosaur Comics (qwantz.com) likes to hide jokes in mailto: links, but
miniflux's sanitizer strips those out. This new rewrite function works around this problem.
