### PR TITLE
Implement streaming responses in the image proxy

### DIFF
--- a/http/response/builder.go
+++ b/http/response/builder.go
@@ -8,6 +8,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -84,6 +85,10 @@ func (b *Builder) Write() {
 		b.compress([]byte(v))
 	case error:
 		b.compress([]byte(v.Error()))
+	case io.Reader:
+		// Compression not implemented in this case
+		b.writeHeaders()
+		io.Copy(b.w, v)
 	}
 }
 


### PR DESCRIPTION
The image proxy buffered the whole image before sending it to the
browser. If the image is large and/or hosted on a slow server, this
meant a long delay before the user's browser could display anything.

(It might be cleaner to just remove the buffering in http/client, and put a `defer resp.Body.Close()` in every caller. If you want, I can update the pull request to implement this.)