### PR TITLE
Add config for days to remove sessions

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -882,6 +882,41 @@ func TestArchiveReadDays(t *testing.T) {
 	}
 }
 
+func TestRemoveSessionsDays(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("REMOVE_SESSIONS_DAYS", "7")
+
+	parser := NewParser()
+	opts, err := parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+
+	expected := 7
+	result := opts.RemoveSessionsDays()
+
+	if result != expected {
+		t.Fatalf(`Unexpected REMOVE_SESSIONS_DAYS value, got %v instead of %v`, result, expected)
+	}
+}
+
+func TestDefaultRemoveSessionsDays(t *testing.T) {
+	os.Clearenv()
+
+	parser := NewParser()
+	opts, err := parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+
+	expected := 30
+	result := opts.RemoveSessionsDays()
+
+	if result != expected {
+		t.Fatalf(`Unexpected REMOVE_SESSIONS_DAYS value, got %v instead of %v`, result, expected)
+	}
+}
+
 func TestRunMigrationsWhenUnset(t *testing.T) {
 	os.Clearenv()
 

--- a/config/options.go
+++ b/config/options.go
@@ -27,6 +27,7 @@ const (
 	defaultDatabaseMaxConns      = 20
 	defaultDatabaseMinConns      = 1
 	defaultArchiveReadDays       = 60
+	defaultRemoveSessionsDays    = 30
 	defaultListenAddr            = "127.0.0.1:8080"
 	defaultCertFile              = ""
 	defaultKeyFile               = ""
@@ -67,6 +68,7 @@ type Options struct {
 	certKeyFile               string
 	cleanupFrequency          int
 	archiveReadDays           int
+	removeSessionsDays        int
 	pollingFrequency          int
 	batchSize                 int
 	workerPoolSize            int
@@ -105,6 +107,7 @@ func NewOptions() *Options {
 		certKeyFile:               defaultKeyFile,
 		cleanupFrequency:          defaultCleanupFrequency,
 		archiveReadDays:           defaultArchiveReadDays,
+		removeSessionsDays:        defaultRemoveSessionsDays,
 		pollingFrequency:          defaultPollingFrequency,
 		batchSize:                 defaultBatchSize,
 		workerPoolSize:            defaultWorkerPoolSize,
@@ -269,6 +272,11 @@ func (o *Options) HasSchedulerService() bool {
 // ArchiveReadDays returns the number of days after which marking read items as removed.
 func (o *Options) ArchiveReadDays() int {
 	return o.archiveReadDays
+}
+
+// RemoveSessionsDays returns the number of days after which to remove sessions.
+func (o *Options) RemoveSessionsDays() int {
+	return o.removeSessionsDays
 }
 
 // PocketConsumerKey returns the Pocket Consumer Key if configured.

--- a/config/parser.go
+++ b/config/parser.go
@@ -118,6 +118,8 @@ func (p *Parser) parseLines(lines []string) (err error) {
 			p.opts.batchSize = parseInt(value, defaultBatchSize)
 		case "ARCHIVE_READ_DAYS":
 			p.opts.archiveReadDays = parseInt(value, defaultArchiveReadDays)
+		case "REMOVE_SESSIONS_DAYS":
+			p.opts.removeSessionsDays = parseInt(value, defaultRemoveSessionsDays)
 		case "PROXY_IMAGES":
 			p.opts.proxyImages = parseString(value, defaultProxyImages)
 		case "CREATE_ADMIN":

--- a/service/scheduler/scheduler.go
+++ b/service/scheduler/scheduler.go
@@ -17,7 +17,7 @@ import (
 func Serve(store *storage.Storage, pool *worker.Pool) {
 	logger.Info(`Starting scheduler...`)
 	go feedScheduler(store, pool, config.Opts.PollingFrequency(), config.Opts.BatchSize())
-	go cleanupScheduler(store, config.Opts.CleanupFrequency(), config.Opts.ArchiveReadDays())
+	go cleanupScheduler(store, config.Opts.CleanupFrequency(), config.Opts.ArchiveReadDays(), config.Opts.RemoveSessionsDays())
 }
 
 func feedScheduler(store *storage.Storage, pool *worker.Pool, frequency, batchSize int) {
@@ -33,11 +33,11 @@ func feedScheduler(store *storage.Storage, pool *worker.Pool, frequency, batchSi
 	}
 }
 
-func cleanupScheduler(store *storage.Storage, frequency int, archiveDays int) {
+func cleanupScheduler(store *storage.Storage, frequency int, archiveDays int, sessionsDays int) {
 	c := time.Tick(time.Duration(frequency) * time.Hour)
 	for range c {
-		nbSessions := store.CleanOldSessions()
-		nbUserSessions := store.CleanOldUserSessions()
+		nbSessions := store.CleanOldSessions(sessionsDays)
+		nbUserSessions := store.CleanOldUserSessions(sessionsDays)
 		logger.Info("[Scheduler:Cleanup] Cleaned %d sessions and %d user sessions", nbSessions, nbUserSessions)
 
 		if err := store.ArchiveEntries(archiveDays); err != nil {

--- a/storage/session.go
+++ b/storage/session.go
@@ -100,10 +100,10 @@ func (s *Storage) FlushAllSessions() (err error) {
 	return nil
 }
 
-// CleanOldSessions removes sessions older than 30 days.
-func (s *Storage) CleanOldSessions() int64 {
-	query := `DELETE FROM sessions
-		WHERE id IN (SELECT id FROM sessions WHERE created_at < now() - interval '30 days')`
+// CleanOldSessions removes sessions older than specified days.
+func (s *Storage) CleanOldSessions(days int) int64 {
+	query := fmt.Sprintf(`DELETE FROM sessions
+		WHERE id IN (SELECT id FROM sessions WHERE created_at < now() - interval '%d days')`, days)
 
 	result, err := s.db.Exec(query)
 	if err != nil {

--- a/storage/user_session.go
+++ b/storage/user_session.go
@@ -124,10 +124,10 @@ func (s *Storage) RemoveUserSessionByID(userID, sessionID int64) error {
 	return nil
 }
 
-// CleanOldUserSessions removes user sessions older than 30 days.
-func (s *Storage) CleanOldUserSessions() int64 {
-	query := `DELETE FROM user_sessions
-		WHERE id IN (SELECT id FROM user_sessions WHERE created_at < now() - interval '30 days')`
+// CleanOldUserSessions removes user sessions older than specified days.
+func (s *Storage) CleanOldUserSessions(days int) int64 {
+	query := fmt.Sprintf(`DELETE FROM user_sessions
+		WHERE id IN (SELECT id FROM user_sessions WHERE created_at < now() - interval '%d days')`, days)
 
 	result, err := s.db.Exec(query)
 	if err != nil {


### PR DESCRIPTION
Resolves #443.

Adds a environment variable, `REMOVE_SESSIONS_DAYS`, to configure the number of days to keep Sessions and UserSessions around before removing them.

Let me know if there are any other tests you'd like to see added, or if you have any other comments.