### PR TITLE
Avoid constraint error when having duplicate entries

### DIFF
--- a/storage/entry.go
+++ b/storage/entry.go
@@ -84,7 +84,7 @@ func (s *Storage) createEntry(entry *model.Entry) error {
 	).Scan(&entry.ID, &entry.Status)
 
 	if err != nil {
-		return fmt.Errorf("unable to create entry %q (feed #%d): %v", entry.URL, entry.FeedID, err)
+		return fmt.Errorf("Unable to create entry %q (feed #%d): %v", entry.URL, entry.FeedID, err)
 	}
 
 	for i := 0; i < len(entry.Enclosures); i++ {
@@ -137,9 +137,9 @@ func (s *Storage) updateEntry(entry *model.Entry) error {
 // entryExists checks if an entry already exists based on its hash when refreshing a feed.
 func (s *Storage) entryExists(entry *model.Entry) bool {
 	var result int
-	query := `SELECT count(*) as c FROM entries WHERE user_id=$1 AND feed_id=$2 AND hash=$3`
+	query := `SELECT 1 FROM entries WHERE user_id=$1 AND feed_id=$2 AND hash=$3`
 	s.db.QueryRow(query, entry.UserID, entry.FeedID, entry.Hash).Scan(&result)
-	return result >= 1
+	return result == 1
 }
 
 // cleanupEntries deletes from the database entries marked as "removed" and not visible anymore in the feed.

--- a/storage/feed.go
+++ b/storage/feed.go
@@ -216,9 +216,12 @@ func (s *Storage) CreateFeed(feed *model.Feed) error {
 	for i := 0; i < len(feed.Entries); i++ {
 		feed.Entries[i].FeedID = feed.ID
 		feed.Entries[i].UserID = feed.UserID
-		err := s.createEntry(feed.Entries[i])
-		if err != nil {
-			return err
+
+		if !s.entryExists(feed.Entries[i]) {
+			err := s.createEntry(feed.Entries[i])
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
During feed creation, duplicated entries will generate an SQL contraint error.

This change ignore the duplicated entry to avoid showing an error.