### PR TITLE
History: show entries in the order in which they were read

### DIFF
--- a/database/migration.go
+++ b/database/migration.go
@@ -12,7 +12,7 @@ import (
 	"miniflux.app/logger"
 )
 
-const schemaVersion = 25
+const schemaVersion = 26
 
 // Migrate executes database migrations.
 func Migrate(db *sql.DB) {

--- a/database/sql.go
+++ b/database/sql.go
@@ -153,6 +153,10 @@ UPDATE users SET theme='light_serif' WHERE theme='default';
 UPDATE users SET theme='light_sans_serif' WHERE theme='sansserif';
 UPDATE users SET theme='dark_serif' WHERE theme='black';
 `,
+	"schema_version_26": `alter table entries add column changed_at timestamp with time zone;
+update entries set changed_at = published_at;
+alter table entries alter column changed_at set not null;
+`,
 	"schema_version_3": `create table tokens (
     id text not null,
     value text not null,
@@ -206,6 +210,7 @@ var SqlMapChecksums = map[string]string{
 	"schema_version_23": "cb3512d328436447f114e305048c0daa8af7505cfe5eab02778b0de1156081b2",
 	"schema_version_24": "1224754c5b9c6b4038599852bbe72656d21b09cb018d3970bd7c00f0019845bf",
 	"schema_version_25": "5262d2d4c88d637b6603a1fcd4f68ad257bd59bd1adf89c58a18ee87b12050d7",
+	"schema_version_26": "64f14add40691f18f514ac0eed10cd9b19c83a35e5c3d8e0bce667e0ceca9094",
 	"schema_version_3":  "a54745dbc1c51c000f74d4e5068f1e2f43e83309f023415b1749a47d5c1e0f12",
 	"schema_version_4":  "216ea3a7d3e1704e40c797b5dc47456517c27dbb6ca98bf88812f4f63d74b5d9",
 	"schema_version_5":  "46397e2f5f2c82116786127e9f6a403e975b14d2ca7b652a48cd1ba843e6a27c",

--- a/database/sql/schema_version_26.sql
+++ b/database/sql/schema_version_26.sql
@@ -1,0 +1,3 @@
+alter table entries add column changed_at timestamp with time zone;
+update entries set changed_at = published_at;
+alter table entries alter column changed_at set not null;

--- a/model/entry.go
+++ b/model/entry.go
@@ -52,11 +52,11 @@ func ValidateEntryStatus(status string) error {
 // ValidateEntryOrder makes sure the sorting order is valid.
 func ValidateEntryOrder(order string) error {
 	switch order {
-	case "id", "status", "published_at", "category_title", "category_id":
+	case "id", "status", "changed_at", "published_at", "category_title", "category_id":
 		return nil
 	}
 
-	return fmt.Errorf(`Invalid entry order, valid order values are: "id", "status", "published_at", "category_title", "category_id"`)
+	return fmt.Errorf(`Invalid entry order, valid order values are: "id", "status", "changed_at", "published_at", "category_title", "category_id"`)
 }
 
 // ValidateDirection makes sure the sorting direction is valid.

--- a/model/entry_test.go
+++ b/model/entry_test.go
@@ -19,7 +19,7 @@ func TestValidateEntryStatus(t *testing.T) {
 }
 
 func TestValidateEntryOrder(t *testing.T) {
-	for _, status := range []string{"id", "status", "published_at", "category_title", "category_id"} {
+	for _, status := range []string{"id", "status", "changed_at", "published_at", "category_title", "category_id"} {
 		if err := ValidateEntryOrder(status); err != nil {
 			t.Error(`A valid order should not generate any error`)
 		}

--- a/storage/entry.go
+++ b/storage/entry.go
@@ -76,9 +76,9 @@ func (s *Storage) UpdateEntryContent(entry *model.Entry) error {
 func (s *Storage) createEntry(entry *model.Entry) error {
 	query := `
 		INSERT INTO entries
-			(title, hash, url, comments_url, published_at, content, author, user_id, feed_id, document_vectors)
+			(title, hash, url, comments_url, published_at, content, author, user_id, feed_id, changed_at, document_vectors)
 		VALUES
-			($1, $2, $3, $4, $5, $6, $7, $8, $9, setweight(to_tsvector(substring(coalesce($1, '') for 1000000)), 'A') || setweight(to_tsvector(substring(coalesce($6, '') for 1000000)), 'B'))
+			($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), setweight(to_tsvector(substring(coalesce($1, '') for 1000000)), 'A') || setweight(to_tsvector(substring(coalesce($6, '') for 1000000)), 'B'))
 		RETURNING
 			id, status
 	`
@@ -231,7 +231,7 @@ func (s *Storage) ArchiveEntries(days int) error {
 
 // SetEntriesStatus update the status of the given list of entries.
 func (s *Storage) SetEntriesStatus(userID int64, entryIDs []int64, status string) error {
-	query := `UPDATE entries SET status=$1 WHERE user_id=$2 AND id=ANY($3)`
+	query := `UPDATE entries SET status=$1, changed_at=now() WHERE user_id=$2 AND id=ANY($3)`
 	result, err := s.db.Exec(query, status, userID, pq.Array(entryIDs))
 	if err != nil {
 		return fmt.Errorf(`store: unable to update entries statuses %v: %v`, entryIDs, err)
@@ -251,7 +251,7 @@ func (s *Storage) SetEntriesStatus(userID int64, entryIDs []int64, status string
 
 // ToggleBookmark toggles entry bookmark value.
 func (s *Storage) ToggleBookmark(userID int64, entryID int64) error {
-	query := `UPDATE entries SET starred = NOT starred WHERE user_id=$1 AND id=$2`
+	query := `UPDATE entries SET starred = NOT starred, changed_at=now() WHERE user_id=$1 AND id=$2`
 	result, err := s.db.Exec(query, userID, entryID)
 	if err != nil {
 		return fmt.Errorf(`store: unable to toggle bookmark flag for entry #%d: %v`, entryID, err)
@@ -271,7 +271,7 @@ func (s *Storage) ToggleBookmark(userID int64, entryID int64) error {
 
 // FlushHistory set all entries with the status "read" to "removed".
 func (s *Storage) FlushHistory(userID int64) error {
-	query := `UPDATE entries SET status=$1 WHERE user_id=$2 AND status=$3 AND starred='f'`
+	query := `UPDATE entries SET status=$1, changed_at=now() WHERE user_id=$2 AND status=$3 AND starred='f'`
 	_, err := s.db.Exec(query, model.EntryStatusRemoved, userID, model.EntryStatusRead)
 	if err != nil {
 		return fmt.Errorf(`store: unable to flush history: %v`, err)
@@ -282,7 +282,7 @@ func (s *Storage) FlushHistory(userID int64) error {
 
 // MarkAllAsRead updates all user entries to the read status.
 func (s *Storage) MarkAllAsRead(userID int64) error {
-	query := `UPDATE entries SET status=$1 WHERE user_id=$2 AND status=$3`
+	query := `UPDATE entries SET status=$1, changed_at=now() WHERE user_id=$2 AND status=$3`
 	result, err := s.db.Exec(query, model.EntryStatusRead, userID, model.EntryStatusUnread)
 	if err != nil {
 		return fmt.Errorf(`store: unable to mark all entries as read: %v`, err)
@@ -300,7 +300,8 @@ func (s *Storage) MarkFeedAsRead(userID, feedID int64, before time.Time) error {
 		UPDATE
 			entries
 		SET
-			status=$1
+			status=$1,
+			changed_at=now()
 		WHERE
 			user_id=$2 AND feed_id=$3 AND status=$4 AND published_at < $5
 	`
@@ -321,7 +322,8 @@ func (s *Storage) MarkCategoryAsRead(userID, categoryID int64, before time.Time)
 		UPDATE
 			entries
 		SET
-			status=$1
+			status=$1,
+			changed_at=now()
 		WHERE
 			user_id=$2
 		AND

--- a/tests/entry_test.go
+++ b/tests/entry_test.go
@@ -257,3 +257,29 @@ func TestToggleBookmark(t *testing.T) {
 		t.Fatal("The entry should be starred")
 	}
 }
+
+func TestHistoryOrder(t *testing.T) {
+	client := createClient(t)
+	createFeed(t, client)
+
+	result, err := client.Entries(&miniflux.Filter{Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selectedEntry := result.Entries[2].ID
+
+	err = client.UpdateEntries([]int64{selectedEntry}, miniflux.EntryStatusRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	history, err := client.Entries(&miniflux.Filter{Order: "changed_at", Direction: "desc", Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if history.Entries[0].ID != selectedEntry {
+		t.Fatal("The entry that we just read should be at the top of the history")
+	}
+}

--- a/ui/history_entries.go
+++ b/ui/history_entries.go
@@ -25,8 +25,8 @@ func (h *handler) showHistoryPage(w http.ResponseWriter, r *http.Request) {
 	offset := request.QueryIntParam(r, "offset", 0)
 	builder := h.store.NewEntryQueryBuilder(user.ID)
 	builder.WithStatus(model.EntryStatusRead)
-	builder.WithOrder(model.DefaultSortingOrder)
-	builder.WithDirection(user.EntryDirection)
+	builder.WithOrder("changed_at")
+	builder.WithDirection("desc")
 	builder.WithOffset(offset)
 	builder.WithLimit(nbItemsPerPage)
 


### PR DESCRIPTION
With these changes, the history view will show entries in the order in which they were read.

This is implemented by adding a changed_at field in the Entries table which tracks when the entry's metadata was changed.

I did this because I often had a hard time finding an entry again after it was marked as read (accidentally or not), but this would also partially address issue #453 and perhaps #298 and #417.