### PR TITLE
Make "v" open link in the current tab on entry page

### DIFF
--- a/ui/static/js.go
+++ b/ui/static/js.go
@@ -75,7 +75,7 @@ function handleFetchOriginalContent(){if(isListView()){return;}
 let element=document.querySelector("a[data-fetch-content-entry]");if(!element){return;}
 if(element.dataset.completed){return;}
 element.innerHTML=element.dataset.labelLoading;let request=new RequestBuilder(element.dataset.fetchContentUrl);request.withCallback((response)=>{element.innerHTML=element.dataset.labelDone;element.dataset.completed=true;response.json().then((data)=>{if(data.hasOwnProperty("content")){document.querySelector(".entry-content").innerHTML=data.content;}});});request.execute();}
-function openOriginalLink(){let entryLink=document.querySelector(".entry h1 a");if(entryLink!==null){DomHelper.openNewTab(entryLink.getAttribute("href"));return;}
+function openOriginalLink(){let entryLink=document.querySelector(".entry h1 a");if(entryLink!==null){window.location.href=entryLink.getAttribute("href");return;}
 let currentItemOriginalLink=document.querySelector(".current-item a[data-original-link]");if(currentItemOriginalLink!==null){DomHelper.openNewTab(currentItemOriginalLink.getAttribute("href"));let currentItem=document.querySelector(".current-item");goToNextListItem();markEntryAsRead(currentItem);}}
 function openSelectedItem(){let currentItemLink=document.querySelector(".current-item .item-title a");if(currentItemLink!==null){window.location.href=currentItemLink.getAttribute("href");}}
 function unsubscribeFromFeed(){let unsubscribeLinks=document.querySelectorAll("[data-action=remove-feed]");if(unsubscribeLinks.length===1){let unsubscribeLink=unsubscribeLinks[0];let request=new RequestBuilder(unsubscribeLink.dataset.url);request.withCallback(()=>{if(unsubscribeLink.dataset.redirectUrl){window.location.href=unsubscribeLink.dataset.redirectUrl;}else{window.location.reload();}});request.execute();}}
@@ -106,6 +106,6 @@ if("serviceWorker"in navigator){let scriptElement=document.getElementById("servi
 }
 
 var JavascriptsChecksums = map[string]string{
-	"app": "a42ba7e5f07586c160c427db8329463bed97fc88e7948c1c7ad9c2e698f620d8",
+	"app": "9689f826a27ae23590f2315519b9850acacf7b357c7cae2bddaa64805c2877ce",
 	"sw":  "55fffa223919cc18572788fb9c62fccf92166c0eb5d3a1d6f91c31f24d020be9",
 }

--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -285,7 +285,7 @@ function handleFetchOriginalContent() {
 function openOriginalLink() {
     let entryLink = document.querySelector(".entry h1 a");
     if (entryLink !== null) {
-        DomHelper.openNewTab(entryLink.getAttribute("href"));
+        window.location.href = entryLink.getAttribute("href");
         return;
     }
 


### PR DESCRIPTION
This is just an idea, what do you think if `v` would open the link in the current tab if you are already viewing a particular entry? 

My assumption is that when you are moving around a list of entries (say "unread" or "feed"), pressing `v` opens url in a new tab so that you can later go back to the list. But if you are already reading a particular entry in full screen, you probably press `v` to go that page to interact with it (read article comments, leave a message on forum, etc.), and it makes more sense to open the link in the current tab.

This would also improve upon #244 to assist with #148. You can open links with `Ctrl+Enter` and then press `v` on those pages.

