### PR TITLE
fix Fever API of marking removed entries

### DIFF
--- a/fever/handler.go
+++ b/fever/handler.go
@@ -398,6 +398,8 @@ func (h *handler) handleWriteItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if entry == nil {
+		logger.Debug("[Fever] Marking entry #%d but not found, ignored", entryID)
+		json.OK(w, r, newBaseResponse())
 		return
 	}
 


### PR DESCRIPTION
This PR fix a Fever Sync problem.

When a client, like `Reeder`, tries to mark an item which is removed on `Miniflux`, the server doesn't response OK. This may terminate the sync process, the PR fixes it.