### PR TITLE
Do no rewrite Youtube description twice in "add_youtube_video" rule

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -143,7 +143,7 @@ func addYoutubeVideo(entryURL, entryContent string) string {
 
 	if len(matches) == 2 {
 		video := `<iframe width="650" height="350" frameborder="0" src="https://www.youtube-nocookie.com/embed/` + matches[1] + `" allowfullscreen></iframe>`
-		return video + "<p>" + replaceLineFeeds(replaceTextLinks(entryContent)) + "</p>"
+		return video + `<br>` + entryContent
 	}
 	return entryContent
 }

--- a/reader/rewrite/rewriter_test.go
+++ b/reader/rewrite/rewriter_test.go
@@ -36,8 +36,8 @@ func TestRewriteWithNoMatchingRule(t *testing.T) {
 }
 
 func TestRewriteWithYoutubeLink(t *testing.T) {
-	output := Rewriter("https://www.youtube.com/watch?v=1234", "Video Description\nhttp://example.org/path", ``)
-	expected := `<iframe width="650" height="350" frameborder="0" src="https://www.youtube-nocookie.com/embed/1234" allowfullscreen></iframe><p>Video Description<br><a href="http://example.org/path">http://example.org/path</a></p>`
+	output := Rewriter("https://www.youtube.com/watch?v=1234", "Video Description", ``)
+	expected := `<iframe width="650" height="350" frameborder="0" src="https://www.youtube-nocookie.com/embed/1234" allowfullscreen></iframe><br>Video Description`
 
 	if expected != output {
 		t.Errorf(`Not expected output: got "%s" instead of "%s"`, output, expected)


### PR DESCRIPTION
This is already done before in <media:description>.