### PR TITLE
filter valid XML char for utf8

### DIFF
--- a/reader/xml/decoder_test.go
+++ b/reader/xml/decoder_test.go
@@ -11,19 +11,74 @@ import (
 	"testing"
 )
 
-func TestIllegalCharacters(t *testing.T) {
+func TestUTF8WithIllegalCharacters(t *testing.T) {
 	type myxml struct {
 		XMLName xml.Name `xml:"rss"`
 		Version string   `xml:"version,attr"`
 		Title   string   `xml:"title"`
 	}
 
-	data := fmt.Sprintf(`<?xml version="1.0" encoding="windows-1251"?><rss version="2.0"><title>%s</title></rss>`, "\x10")
+	expected := "Title & 中文标题"
+	data := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><title>Title & 中文%s标题</title></rss>`, "\x10")
+	reader := strings.NewReader(data)
+
 	var x myxml
 
-	decoder := NewDecoder(strings.NewReader(data))
+	decoder := NewDecoder(reader)
 	err := decoder.Decode(&x)
 	if err != nil {
 		t.Error(err)
+		return
+	}
+	if x.Title != expected {
+		t.Errorf("Incorrect entry title, expected: %s, got: %s", expected, x.Title)
+	}
+}
+
+func TestWindows251WithIllegalCharacters(t *testing.T) {
+	type myxml struct {
+		XMLName xml.Name `xml:"rss"`
+		Version string   `xml:"version,attr"`
+		Title   string   `xml:"title"`
+	}
+
+	expected := "Title & 中文标题"
+	data := fmt.Sprintf(`<?xml version="1.0" encoding="windows-1251"?><rss version="2.0"><title>Title & 中文%s标题</title></rss>`, "\x10")
+	reader := strings.NewReader(data)
+
+	var x myxml
+
+	decoder := NewDecoder(reader)
+	err := decoder.Decode(&x)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if x.Title != expected {
+		t.Errorf("Incorrect entry title, expected: %s, got: %s", expected, x.Title)
+	}
+}
+
+func TestIllegalEncodingField(t *testing.T) {
+	type myxml struct {
+		XMLName xml.Name `xml:"rss"`
+		Version string   `xml:"version,attr"`
+		Title   string   `xml:"title"`
+	}
+
+	expected := "Title & 中文标题"
+	data := fmt.Sprintf(`<?xml version="1.0" encoding="invalid"?><rss version="2.0"><title>Title & 中文%s标题</title></rss>`, "\x10")
+	reader := strings.NewReader(data)
+
+	var x myxml
+
+	decoder := NewDecoder(reader)
+	err := decoder.Decode(&x)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if x.Title != expected {
+		t.Errorf("Incorrect entry title, expected: %s, got: %s", expected, x.Title)
 	}
 }


### PR DESCRIPTION
I encounter similar problem with #492 by `"XML syntax error on line xxx: illegal character code U+0008"`, this PR fix it：

`xml.Decoder.CharsetReader` only applies to non-UTF-8 data, so it did't filter invalid runes for UTF-8 data