### PR TITLE
UX: align items to reach "static ones" in a consistent way

### DIFF
--- a/ui/static/css/common.css
+++ b/ui/static/css/common.css
@@ -648,6 +648,7 @@ a.button {
 
 .item-meta ul {
     margin-top: 5px;
+    float: right;
 }
 
 .item-meta li {


### PR DESCRIPTION
As the first item (feed name) and second item (date of publication of the post) are not of constant length, it requires unnecessary hand and eyes efforts to reach for static items (save, original, star, read). I infer from my experience that those static items may be the most used. Static items should stay at the very same place in the interface to improve user experience (at least mine :-) ).