### PR TITLE
Return outer HTML when scraping elements

### DIFF
--- a/reader/scraper/scraper.go
+++ b/reader/scraper/scraper.go
@@ -75,13 +75,7 @@ func scrapContent(page io.Reader, rules string) (string, error) {
 	document.Find(rules).Each(func(i int, s *goquery.Selection) {
 		var content string
 
-		// For some inline elements, we get the parent.
-		if s.Is("img") || s.Is("iframe") {
-			content, _ = s.Parent().Html()
-		} else {
-			content, _ = s.Html()
-		}
-
+		content, _ = goquery.OuterHtml(s)
 		contents += content
 	})
 

--- a/reader/scraper/testdata/iframe.html
+++ b/reader/scraper/testdata/iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-US">
+	<body>
+		<article>
+			<iframe id="1" src="about:blank"></iframe>
+			<iframe id="2" src="about:blank"></iframe>
+			<iframe id="3" src="about:blank"></iframe>
+			<iframe id="4" src="about:blank"></iframe>
+			<iframe id="5" src="about:blank"></iframe>
+		</article>
+	</body>
+</html>

--- a/reader/scraper/testdata/iframe.html-result
+++ b/reader/scraper/testdata/iframe.html-result
@@ -1,0 +1,1 @@
+<iframe id="1" src="about:blank"></iframe><iframe id="2" src="about:blank"></iframe><iframe id="3" src="about:blank"></iframe><iframe id="4" src="about:blank"></iframe><iframe id="5" src="about:blank"></iframe>

--- a/reader/scraper/testdata/img.html
+++ b/reader/scraper/testdata/img.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-US">
+	<body>
+		<article>
+			<img id="1" src="#" alt="" />
+			<img id="2" src="#" alt="" />
+			<img id="3" src="#" alt="" />
+			<img id="4" src="#" alt="" />
+			<img id="5" src="#" alt="" />
+		</article>
+	</body>
+</html>

--- a/reader/scraper/testdata/img.html-result
+++ b/reader/scraper/testdata/img.html-result
@@ -1,0 +1,1 @@
+<img id="1" src="#" alt=""/><img id="2" src="#" alt=""/><img id="3" src="#" alt=""/><img id="4" src="#" alt=""/><img id="5" src="#" alt=""/>

--- a/reader/scraper/testdata/p.html
+++ b/reader/scraper/testdata/p.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en-US">
+	<body>
+		<article>
+			<p>Lorem ipsum dolor sit amet, consectetuer adipiscing ept.</p>
+			<p>Apquam tincidunt mauris eu risus.</p>
+			<p>Vestibulum auctor dapibus neque.</p>
+		</article>
+	</body>
+</html>

--- a/reader/scraper/testdata/p.html-result
+++ b/reader/scraper/testdata/p.html-result
@@ -1,0 +1,1 @@
+<p>Lorem ipsum dolor sit amet, consectetuer adipiscing ept.</p><p>Apquam tincidunt mauris eu risus.</p><p>Vestibulum auctor dapibus neque.</p>


### PR DESCRIPTION
This fixes the issues below:

---

If the parent element has multiple \<img/iframe>'s inside it, the scraper will return the parent element multiple times.
```css
<div id="_imageList">
    <img><img><img><img><img>
</div>
```
`#_imageList > img` will cause the scraper to return the \<div> element five times.

---

When scraping \<p> elements the \<p> gets stripped leaving only the text which breaks formatting.
```css
<article>
    <p>Example!</p>
    <p>Text Here.</p>
    <p>More Text.</p>
</article>
```
`article > p` will return "Example!Text Here.More Text.".