### PR TITLE
Add support for Atom 'replies' link relation

### DIFF
--- a/reader/atom/atom.go
+++ b/reader/atom/atom.go
@@ -99,6 +99,7 @@ func (a *atomEntry) Transform() *model.Entry {
 	entry.Content = getContent(a)
 	entry.Title = getTitle(a)
 	entry.Enclosures = getEnclosures(a)
+	entry.CommentsURL = getRelationURLWithType(a.Links, "replies", "text/html")
 	return entry
 }
 
@@ -119,6 +120,16 @@ func getURL(links []atomLink) string {
 func getRelationURL(links []atomLink, relation string) string {
 	for _, link := range links {
 		if strings.ToLower(link.Rel) == relation {
+			return strings.TrimSpace(link.URL)
+		}
+	}
+
+	return ""
+}
+
+func getRelationURLWithType(links []atomLink, relation, contentType string) string {
+	for _, link := range links {
+		if strings.ToLower(link.Rel) == relation && strings.ToLower(link.Type) == contentType {
 			return strings.TrimSpace(link.URL)
 		}
 	}

--- a/reader/atom/parser_test.go
+++ b/reader/atom/parser_test.go
@@ -65,6 +65,10 @@ func TestParseAtomSample(t *testing.T) {
 		t.Errorf("Incorrect entry URL, got: %s", feed.Entries[0].URL)
 	}
 
+	if feed.Entries[0].CommentsURL != "" {
+		t.Errorf("Incorrect entry Comments URL, got: %s", feed.Entries[0].CommentsURL)
+	}
+
 	if feed.Entries[0].Title != "Atom-Powered Robots Run Amok" {
 		t.Errorf("Incorrect entry title, got: %s", feed.Entries[0].Title)
 	}
@@ -727,5 +731,49 @@ A website: http://example.org/</media:description>
 		if expectedResults[index].size != enclosure.Size {
 			t.Errorf(`Unexpected enclosure size, got %d instead of %d`, enclosure.Size, expectedResults[index].size)
 		}
+	}
+}
+
+func TestParseRepliesLinkRelation(t *testing.T) {
+	data := `<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom"
+			xmlns:thr="http://purl.org/syndication/thread/1.0">
+		<id>http://www.example.org/myfeed</id>
+		<title>My Example Feed</title>
+		<updated>2005-07-28T12:00:00Z</updated>
+		<link href="http://www.example.org/myfeed" />
+		<author><name>James</name></author>
+		<entry>
+			<id>tag:entries.com,2005:1</id>
+			<title>My original entry</title>
+			<updated>2006-03-01T12:12:12Z</updated>
+			<link href="http://www.example.org/entries/1" />
+			<link rel="replies"
+				type="application/atom+xml"
+				href="http://www.example.org/mycommentsfeed.xml"
+				thr:count="10" thr:updated="2005-07-28T12:10:00Z" />
+			<link rel="replies"
+				type="text/html"
+				href="http://www.example.org/comments.html"
+				thr:count="10" thr:updated="2005-07-28T12:10:00Z" />
+			<summary>This is my original entry</summary>
+		</entry>
+	</feed>`
+
+	feed, err := Parse(bytes.NewBufferString(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(feed.Entries) != 1 {
+		t.Errorf("Incorrect number of entries, got: %d", len(feed.Entries))
+	}
+
+	if feed.Entries[0].URL != "http://www.example.org/entries/1" {
+		t.Errorf("Incorrect entry URL, got: %s", feed.Entries[0].URL)
+	}
+
+	if feed.Entries[0].CommentsURL != "http://www.example.org/comments.html" {
+		t.Errorf("Incorrect entry comments URL, got: %s", feed.Entries[0].CommentsURL)
 	}
 }


### PR DESCRIPTION
Show comments URL for Atom feeds as per RFC 4685.
See https://tools.ietf.org/html/rfc4685#section-4

Note that only the first link with type "text/html" is taken into consideration.