### PR TITLE
Redirect to /unread when getting a 404 for an unread expired entry

### DIFF
--- a/ui/entry_unread.go
+++ b/ui/entry_unread.go
@@ -35,7 +35,7 @@ func (h *handler) showUnreadEntryPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if entry == nil {
-		html.NotFound(w, r)
+		html.Redirect(w, r, route.Path(h.router, "unread"))
 		return
 	}
 


### PR DESCRIPTION
Hosted miniflux don't keep read entries for long. If I leave my PC at
home on an unread entry, read everything pending at work and get back
to home later, when I click "next", I get a bare 404 error. I have to
go back to /unread myself. I think it would be more user friendly (but
maybe a bit suprising) to go directly to /unread in this case.

Note that I didn't test the change. It seems trivial to me and I think you'll be faster than me to test (or to reject if you think that's a bad idea).