### PR TITLE
Add refreshAllFeeds to the API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,13 +7,14 @@ package api // import "miniflux.app/api"
 import (
 	"miniflux.app/reader/feed"
 	"miniflux.app/storage"
+	"miniflux.app/worker"
 
 	"github.com/gorilla/mux"
 )
 
 // Serve declares API routes for the application.
-func Serve(router *mux.Router, store *storage.Storage, feedHandler *feed.Handler) {
-	handler := &handler{store, feedHandler}
+func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool, feedHandler *feed.Handler) {
+	handler := &handler{store, pool, feedHandler}
 
 	sr := router.PathPrefix("/v1").Subrouter()
 	sr.Use(newMiddleware(store).serve)
@@ -31,6 +32,7 @@ func Serve(router *mux.Router, store *storage.Storage, feedHandler *feed.Handler
 	sr.HandleFunc("/discover", handler.getSubscriptions).Methods("POST")
 	sr.HandleFunc("/feeds", handler.createFeed).Methods("POST")
 	sr.HandleFunc("/feeds", handler.getFeeds).Methods("GET")
+	sr.HandleFunc("/feeds/refresh", handler.refreshAllFeeds).Methods("PUT")
 	sr.HandleFunc("/feeds/{feedID}/refresh", handler.refreshFeed).Methods("PUT")
 	sr.HandleFunc("/feeds/{feedID}", handler.getFeed).Methods("GET")
 	sr.HandleFunc("/feeds/{feedID}", handler.updateFeed).Methods("PUT")

--- a/api/feed.go
+++ b/api/feed.go
@@ -82,6 +82,21 @@ func (h *handler) refreshFeed(w http.ResponseWriter, r *http.Request) {
 	json.NoContent(w, r)
 }
 
+func (h *handler) refreshAllFeeds(w http.ResponseWriter, r *http.Request) {
+	userID := request.UserID(r)
+	jobs, err := h.store.NewUserBatch(userID, h.store.CountFeeds(userID))
+	if err != nil {
+		json.ServerError(w, r, err)
+		return
+	}
+
+	go func() {
+		h.pool.Push(jobs)
+	}()
+
+	json.NoContent(w, r)
+}
+
 func (h *handler) updateFeed(w http.ResponseWriter, r *http.Request) {
 	feedID := request.RouteInt64Param(r, "feedID")
 	feedChanges, err := decodeFeedModificationPayload(r.Body)

--- a/api/handler.go
+++ b/api/handler.go
@@ -7,9 +7,11 @@ package api // import "miniflux.app/api"
 import (
 	"miniflux.app/reader/feed"
 	"miniflux.app/storage"
+	"miniflux.app/worker"
 )
 
 type handler struct {
 	store       *storage.Storage
+	pool        *worker.Pool
 	feedHandler *feed.Handler
 }

--- a/service/httpd/httpd.go
+++ b/service/httpd/httpd.go
@@ -166,7 +166,7 @@ func setupHandler(store *storage.Storage, feedHandler *feed.Handler, pool *worke
 	router.Use(middleware)
 
 	fever.Serve(router, store)
-	api.Serve(router, store, feedHandler)
+	api.Serve(router, store, pool, feedHandler)
 	ui.Serve(router, store, pool, feedHandler)
 
 	router.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds refreshAllFeeds to the API, following the suggestion given in the comments of #359.

This provides a way to remotely trigger a background refresh of all feeds. This can be useful in a situation where a more complex refresh schedule is needed, or where the miniflux process is subject to aggressive sleep policies (such as free heroku dynos #307, or on GAE #324).