### PR TITLE
Addition of scraper rule for wdwnt.com

### DIFF
--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -36,6 +36,7 @@ var predefinedRules = map[string]string{
 	"theregister.co.uk":   "#body",
 	"universfreebox.com":  "#corps_corps",
 	"version2.dk":         "section.body",
+	"wdwnt.com":           "div.entry-content",
 	"wired.com":           "main figure, article",
 	"zeit.de":             ".summary, .article-body",
 	"zdnet.com":           "div.storyBody",


### PR DESCRIPTION
By default fetching original content for wdwnt.com results in a snippet of the comments section, this rule captures the article content.