### PR TITLE
Add config for redirect to a canonical host from a non-canonical host

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -137,6 +137,41 @@ func TestDefaultBaseURL(t *testing.T) {
 	}
 }
 
+func TestCanonicalHostRedirectWhenUnset(t *testing.T) {
+	os.Clearenv()
+
+	parser := NewParser()
+	opts, err := parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+
+	expected := false
+	result := opts.IsCanonicalHostRedirectEnabled()
+
+	if result != expected {
+		t.Fatalf(`Unexpected CANONICAL_HOST_REDIRECT value, got %v instead of %v`, result, expected)
+	}
+}
+
+func TestCanonicalHostRedirect(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("CANONICAL_HOST_REDIRECT", "1")
+
+	parser := NewParser()
+	opts, err := parser.ParseEnvironmentVariables()
+	if err != nil {
+		t.Fatalf(`Parsing failure: %v`, err)
+	}
+
+	expected := true
+	result := opts.IsCanonicalHostRedirectEnabled()
+
+	if result != expected {
+		t.Fatalf(`Unexpected CANONICAL_HOST_REDIRECT value, got %v instead of %v`, result, expected)
+	}
+}
+
 func TestDatabaseURL(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("DATABASE_URL", "foobar")

--- a/config/options.go
+++ b/config/options.go
@@ -19,6 +19,8 @@ const (
 	defaultBaseURL                     = "http://localhost"
 	defaultRootURL                     = "http://localhost"
 	defaultBasePath                    = ""
+	defaultHost                        = "localhost"
+	defaultCanonicalHostRedirect       = false
 	defaultWorkerPoolSize              = 5
 	defaultPollingFrequency            = 60
 	defaultBatchSize                   = 10
@@ -60,6 +62,8 @@ type Options struct {
 	baseURL                     string
 	rootURL                     string
 	basePath                    string
+	host                        string
+	canonicalHostRedirect       bool
 	databaseURL                 string
 	databaseMaxConns            int
 	databaseMinConns            int
@@ -102,6 +106,8 @@ func NewOptions() *Options {
 		baseURL:                     defaultBaseURL,
 		rootURL:                     defaultRootURL,
 		basePath:                    defaultBasePath,
+		host:                        defaultHost,
+		canonicalHostRedirect:       defaultCanonicalHostRedirect,
 		databaseURL:                 defaultDatabaseURL,
 		databaseMaxConns:            defaultDatabaseMaxConns,
 		databaseMinConns:            defaultDatabaseMinConns,
@@ -156,6 +162,17 @@ func (o *Options) RootURL() string {
 // BasePath returns the application base path according to the base URL.
 func (o *Options) BasePath() string {
 	return o.basePath
+}
+
+// Host returns the application host according to the base URL.
+func (o *Options) Host() string {
+	return o.host
+}
+
+// IsCanonicalHostRedirectEnabled returns true if a redirect to a canonical
+// host from a non-canonical host is enabled.
+func (o *Options) IsCanonicalHostRedirectEnabled() bool {
+	return o.canonicalHostRedirect
 }
 
 // IsDefaultDatabaseURL returns true if the default database URL is used.
@@ -334,6 +351,7 @@ func (o *Options) String() string {
 	builder.WriteString(fmt.Sprintf("BASE_URL: %v\n", o.baseURL))
 	builder.WriteString(fmt.Sprintf("ROOT_URL: %v\n", o.rootURL))
 	builder.WriteString(fmt.Sprintf("BASE_PATH: %v\n", o.basePath))
+	builder.WriteString(fmt.Sprintf("CANONICAL_HOST_REDIRECT: %v\n", o.canonicalHostRedirect))
 	builder.WriteString(fmt.Sprintf("LISTEN_ADDR: %v\n", o.listenAddr))
 	builder.WriteString(fmt.Sprintf("DATABASE_URL: %v\n", o.databaseURL))
 	builder.WriteString(fmt.Sprintf("DATABASE_MAX_CONNS: %v\n", o.databaseMaxConns))

--- a/service/httpd/middleware.go
+++ b/service/httpd/middleware.go
@@ -28,6 +28,12 @@ func middleware(next http.Handler) http.Handler {
 			protocol = "HTTPS"
 		}
 
+		if config.Opts.IsCanonicalHostRedirectEnabled() && config.Opts.Host() != r.Host {
+			url := r.URL
+			url.Host = config.Opts.Host()
+			http.Redirect(w, r, url.String(), http.StatusMovedPermanently)
+		}
+
 		logger.Debug("[%s] %s %s %s", protocol, clientIP, r.Method, r.RequestURI)
 
 		if config.Opts.HTTPS && config.Opts.HasHSTS() {


### PR DESCRIPTION
Adds a config variable, `CANONICAL_HOST_REDIRECT`, to enable redirect to a canonical host from a non-canonical host. Canonical host is deduced from a `BASE_URL` config variable.

This is helpful on Heroku when running Miniflux at a custom domain to redirect from a `*.herokuapp.com` domain.