### PR TITLE
Added scraper rule for RayWenderlich.com

### DIFF
--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -31,6 +31,7 @@ var predefinedRules = map[string]string{
 	"osnews.com":          "div.newscontent1",
 	"phoronix.com":        "div.content",
 	"pseudo-sciences.org": "#art_main",
+	"raywenderlich.com":   "article",
 	"slate.fr":            ".field-items",
 	"techcrunch.com":      "div.article-entry",
 	"theregister.co.uk":   "#body",

--- a/reader/scraper/rules.go
+++ b/reader/scraper/rules.go
@@ -34,6 +34,7 @@ var predefinedRules = map[string]string{
 	"raywenderlich.com":   "article",
 	"slate.fr":            ".field-items",
 	"techcrunch.com":      "div.article-entry",
+	"theoatmeal.com":      "div#comic",
 	"theregister.co.uk":   "#body",
 	"universfreebox.com":  "#corps_corps",
 	"version2.dk":         "section.body",


### PR DESCRIPTION
RayWenderlich.com is a popular developer's community for iOS and Android developers. The default rule results in "GROUP GROUP GROUP GROUP…" instead of the content posted on the blog.