### PR TITLE
Let users choose if they want top pagination to always show, even on small entries

### DIFF
--- a/database/migration.go
+++ b/database/migration.go
@@ -12,7 +12,7 @@ import (
 	"miniflux.app/logger"
 )
 
-const schemaVersion = 31
+const schemaVersion = 32
 
 // Migrate executes database migrations.
 func Migrate(db *sql.DB) {

--- a/database/sql.go
+++ b/database/sql.go
@@ -183,6 +183,7 @@ create unique index entries_share_code_idx on entries using btree(share_code) wh
 create index entries_user_feed_idx on entries (user_id, feed_id);
 `,
 	"schema_version_31": `alter table feeds add column ignore_http_cache bool default false;`,
+	"schema_version_32": `alter table users add column show_short_pagination boolean default 'f';`,
 	"schema_version_4": `create type entry_sorting_direction as enum('asc', 'desc');
 alter table users add column entry_direction entry_sorting_direction default 'asc';
 `,
@@ -237,6 +238,7 @@ var SqlMapChecksums = map[string]string{
 	"schema_version_3":  "a54745dbc1c51c000f74d4e5068f1e2f43e83309f023415b1749a47d5c1e0f12",
 	"schema_version_30": "3ec48a9b2e7a0fc32c85f31652f723565c34213f5f2d7e5e5076aad8f0b40d23",
 	"schema_version_31": "9290ef295731b03ddfe32dcaded0be70d41b63572420ad379cf2874a9b54581c",
+	"schema_version_32": "43f331c992c3e11de590dd9439ec3977e1f7915e9b4deaf6be4e40cb299bee20",
 	"schema_version_4":  "216ea3a7d3e1704e40c797b5dc47456517c27dbb6ca98bf88812f4f63d74b5d9",
 	"schema_version_5":  "46397e2f5f2c82116786127e9f6a403e975b14d2ca7b652a48cd1ba843e6a27c",
 	"schema_version_6":  "9d05b4fb223f0e60efc716add5048b0ca9c37511cf2041721e20505d6d798ce4",

--- a/database/sql/schema_version_32.sql
+++ b/database/sql/schema_version_32.sql
@@ -1,0 +1,1 @@
+alter table users add column show_short_pagination boolean default 'f';

--- a/locale/translations.go
+++ b/locale/translations.go
@@ -600,6 +600,7 @@ var translations = map[string]string{
     "form.prefs.select.older_first": "Older entries first",
     "form.prefs.select.recent_first": "Recent entries first",
     "form.prefs.label.keyboard_shortcuts": "Enable keyboard shortcuts",
+    "form.prefs.label.show_short_pagination": "Show all pagination controls on short articles",
     "form.prefs.label.custom_css": "Custom CSS",
     "form.import.label.file": "OPML file",
     "form.import.label.url": "URL",
@@ -3290,7 +3291,7 @@ var translations = map[string]string{
 
 var translationsChecksums = map[string]string{
 	"de_DE": "ddb063682852c86361af350be616d3bd328373ecb927804824008d016aa7c67c",
-	"en_US": "350b835f759212abd2110322394aa00b666fbf27d752532a7700fb52d5af3f02",
+	"en_US": "b270222524b9c3d2213294f79e3799a8a09ac609b9d8c78f2ce916d9ad5db92b",
 	"es_ES": "26efc79faaf35efe5a33528cedc2522496987d290c9e86d8fff3a9bcbed3e441",
 	"fr_FR": "e8736791d5373b955cacce215b3ae67d56280bfa5d4596899e4e5e37ff962afd",
 	"it_IT": "41e6eba2d92a684ef90462226db312285d1d94a07a5bb917cfce4f64df290a86",

--- a/locale/translations/en_US.json
+++ b/locale/translations/en_US.json
@@ -257,6 +257,7 @@
     "form.prefs.select.older_first": "Older entries first",
     "form.prefs.select.recent_first": "Recent entries first",
     "form.prefs.label.keyboard_shortcuts": "Enable keyboard shortcuts",
+    "form.prefs.label.show_short_pagination": "Show all pagination controls on short articles",
     "form.prefs.label.custom_css": "Custom CSS",
     "form.import.label.file": "OPML file",
     "form.import.label.url": "URL",

--- a/model/user.go
+++ b/model/user.go
@@ -13,17 +13,18 @@ import (
 
 // User represents a user in the system.
 type User struct {
-	ID                int64             `json:"id"`
-	Username          string            `json:"username"`
-	Password          string            `json:"password,omitempty"`
-	IsAdmin           bool              `json:"is_admin"`
-	Theme             string            `json:"theme"`
-	Language          string            `json:"language"`
-	Timezone          string            `json:"timezone"`
-	EntryDirection    string            `json:"entry_sorting_direction"`
-	KeyboardShortcuts bool              `json:"keyboard_shortcuts"`
-	LastLoginAt       *time.Time        `json:"last_login_at,omitempty"`
-	Extra             map[string]string `json:"extra"`
+	ID                  int64             `json:"id"`
+	Username            string            `json:"username"`
+	Password            string            `json:"password,omitempty"`
+	IsAdmin             bool              `json:"is_admin"`
+	Theme               string            `json:"theme"`
+	Language            string            `json:"language"`
+	Timezone            string            `json:"timezone"`
+	EntryDirection      string            `json:"entry_sorting_direction"`
+	KeyboardShortcuts   bool              `json:"keyboard_shortcuts"`
+	ShowShortPagination bool              `json:"show_short_pagination"`
+	LastLoginAt         *time.Time        `json:"last_login_at,omitempty"`
+	Extra               map[string]string `json:"extra"`
 }
 
 // NewUser returns a new User.

--- a/storage/user.go
+++ b/storage/user.go
@@ -64,7 +64,7 @@ func (s *Storage) CreateUser(user *model.User) (err error) {
 		VALUES
 			(LOWER($1), $2, $3, $4)
 		RETURNING
-			id, username, is_admin, language, theme, timezone, entry_direction, keyboard_shortcuts
+			id, username, is_admin, language, theme, timezone, entry_direction, keyboard_shortcuts, show_short_pagination
 	`
 
 	err = s.db.QueryRow(query, user.Username, password, user.IsAdmin, extra).Scan(
@@ -76,6 +76,7 @@ func (s *Storage) CreateUser(user *model.User) (err error) {
 		&user.Timezone,
 		&user.EntryDirection,
 		&user.KeyboardShortcuts,
+		&user.ShowShortPagination,
 	)
 	if err != nil {
 		return fmt.Errorf(`store: unable to create user: %v`, err)
@@ -123,9 +124,10 @@ func (s *Storage) UpdateUser(user *model.User) error {
 				language=$5,
 				timezone=$6,
 				entry_direction=$7,
-				keyboard_shortcuts=$8
+				keyboard_shortcuts=$8,
+				show_short_pagination=$9
 			WHERE
-				id=$9
+				id=$10
 		`
 
 		_, err = s.db.Exec(
@@ -138,6 +140,7 @@ func (s *Storage) UpdateUser(user *model.User) error {
 			user.Timezone,
 			user.EntryDirection,
 			user.KeyboardShortcuts,
+			user.ShowShortPagination,
 			user.ID,
 		)
 		if err != nil {
@@ -152,9 +155,10 @@ func (s *Storage) UpdateUser(user *model.User) error {
 				language=$4,
 				timezone=$5,
 				entry_direction=$6,
-				keyboard_shortcuts=$7
+				keyboard_shortcuts=$7,
+				show_short_pagination=$8
 			WHERE
-				id=$8
+				id=$9
 		`
 
 		_, err := s.db.Exec(
@@ -166,6 +170,7 @@ func (s *Storage) UpdateUser(user *model.User) error {
 			user.Timezone,
 			user.EntryDirection,
 			user.KeyboardShortcuts,
+			user.ShowShortPagination,
 			user.ID,
 		)
 
@@ -204,6 +209,7 @@ func (s *Storage) UserByID(userID int64) (*model.User, error) {
 			entry_direction,
 			keyboard_shortcuts,
 			last_login_at,
+			show_short_pagination,
 			extra
 		FROM
 			users
@@ -226,6 +232,7 @@ func (s *Storage) UserByUsername(username string) (*model.User, error) {
 			entry_direction,
 			keyboard_shortcuts,
 			last_login_at,
+			show_short_pagination,
 			extra
 		FROM
 			users
@@ -248,6 +255,7 @@ func (s *Storage) UserByExtraField(field, value string) (*model.User, error) {
 			entry_direction,
 			keyboard_shortcuts,
 			last_login_at,
+			show_short_pagination,
 			extra
 		FROM
 			users
@@ -270,6 +278,7 @@ func (s *Storage) UserByAPIKey(token string) (*model.User, error) {
 			u.entry_direction,
 			u.keyboard_shortcuts,
 			u.last_login_at,
+			u.show_short_pagination,
 			u.extra
 		FROM
 			users u
@@ -295,6 +304,7 @@ func (s *Storage) fetchUser(query string, args ...interface{}) (*model.User, err
 		&user.EntryDirection,
 		&user.KeyboardShortcuts,
 		&user.LastLoginAt,
+		&user.ShowShortPagination,
 		&extra,
 	)
 
@@ -350,6 +360,7 @@ func (s *Storage) Users() (model.Users, error) {
 			entry_direction,
 			keyboard_shortcuts,
 			last_login_at,
+			show_short_pagination,
 			extra
 		FROM
 			users
@@ -375,6 +386,7 @@ func (s *Storage) Users() (model.Users, error) {
 			&user.EntryDirection,
 			&user.KeyboardShortcuts,
 			&user.LastLoginAt,
+			&user.ShowShortPagination,
 			&extra,
 		)
 

--- a/template/html/entry.html
+++ b/template/html/entry.html
@@ -111,7 +111,7 @@
             {{ end }}
         </div>
     </header>
-    {{ if gt (len .entry.Content) 120 }}
+    {{ if gt (len .entry.Content) 120 or .user.ShowPaginationControls }}
     {{ if .user }}
     <div class="pagination-top">
         {{ template "entry_pagination" . }}

--- a/template/html/settings.html
+++ b/template/html/settings.html
@@ -51,6 +51,8 @@
 
     <label><input type="checkbox" name="keyboard_shortcuts" value="1" {{ if .form.KeyboardShortcuts }}checked{{ end }}> {{ t "form.prefs.label.keyboard_shortcuts" }}</label>
 
+    <label><input type="checkbox" name="show_short_pagination" value="1" {{ if .form.ShowShortPagination }}checked{{ end }}> {{ t "form.prefs.label.show_short_pagination" }}</label>
+
     <label>{{t "form.prefs.label.custom_css" }}</label><textarea name="custom_css" cols="40" rows="5">{{ .form.CustomCSS }}</textarea>
     <div class="buttons">
         <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>

--- a/template/views.go
+++ b/template/views.go
@@ -767,7 +767,7 @@ var templateViewsMap = map[string]string{
             {{ end }}
         </div>
     </header>
-    {{ if gt (len .entry.Content) 120 }}
+    {{ if gt (len .entry.Content) 120 or .user.ShowPaginationControls }}
     {{ if .user }}
     <div class="pagination-top">
         {{ template "entry_pagination" . }}
@@ -1556,7 +1556,7 @@ var templateViewsMapChecksums = map[string]string{
 	"edit_category":       "b1c0b38f1b714c5d884edcd61e5b5295a5f1c8b71c469b35391e4dcc97cc6d36",
 	"edit_feed":           "635bb8f7b927f3216ccd35cc6d9edd4b2af96e8677a14766a86fb77fa9fb4e38",
 	"edit_user":           "c692db9de1a084c57b93e95a14b041d39bf489846cbb91fc982a62b72b77062a",
-	"entry":               "d8c30d412d58e14c946ba682166f7c582948e7b0f657d04dcbc3d004267627bb",
+	"entry":               "29d826d9a19e2586a102872d154ec89fa809ce55dab6b83c902fa7ae180e3ac0",
 	"feed_entries":        "614357a9369237e54be45b40c516fe70a751bfb4311660746ae229e6be88fdac",
 	"feeds":               "ec7d3fa96735bd8422ba69ef0927dcccddc1cc51327e0271f0312d3f881c64fd",
 	"history_entries":     "93c0c4cc541eec7f07f5c2634f250ea82ac64024939179276b6f636b72c189bf",

--- a/template/views.go
+++ b/template/views.go
@@ -1322,6 +1322,8 @@ var templateViewsMap = map[string]string{
 
     <label><input type="checkbox" name="keyboard_shortcuts" value="1" {{ if .form.KeyboardShortcuts }}checked{{ end }}> {{ t "form.prefs.label.keyboard_shortcuts" }}</label>
 
+    <label><input type="checkbox" name="show_short_pagination" value="1" {{ if .form.ShowShortPagination }}checked{{ end }}> {{ t "form.prefs.label.show_short_pagination" }}</label>
+
     <label>{{t "form.prefs.label.custom_css" }}</label><textarea name="custom_css" cols="40" rows="5">{{ .form.CustomCSS }}</textarea>
     <div class="buttons">
         <button type="submit" class="button button-primary" data-label-loading="{{ t "form.submit.saving" }}">{{ t "action.update" }}</button>
@@ -1565,7 +1567,7 @@ var templateViewsMapChecksums = map[string]string{
 	"login":               "79ff2ca488c0a19b37c8fa227a21f73e94472eb357a51a077197c852f7713f11",
 	"search_entries":      "274950d03298c24f3942e209c0faed580a6d57be9cf76a6c236175a7e766ac6a",
 	"sessions":            "5d5c677bddbd027e0b0c9f7a0dd95b66d9d95b4e130959f31fb955b926c2201c",
-	"settings":            "3ab566c3220c62edc3edc51f2e93c1101b728e9f62f52f23de6bc6322d86aeb6",
+	"settings":            "7854832769db0f3fdeab099fff1241656173b5d19416b3dbaa6ee022e56001f8",
 	"shared_entries":      "19caea053664220bb9519df295eb2a17cf5836eaa9104b7ee24c60b88bb524e9",
 	"unread_entries":      "e38f7ffce17dfad3151b08cd33771a2cefe8ca9db42df04fc98bd1d675dd6075",
 	"users":               "d7ff52efc582bbad10504f4a04fa3adcc12d15890e45dff51cac281e0c446e45",

--- a/ui/form/settings.go
+++ b/ui/form/settings.go
@@ -13,15 +13,16 @@ import (
 
 // SettingsForm represents the settings form.
 type SettingsForm struct {
-	Username          string
-	Password          string
-	Confirmation      string
-	Theme             string
-	Language          string
-	Timezone          string
-	EntryDirection    string
-	KeyboardShortcuts bool
-	CustomCSS         string
+	Username            string
+	Password            string
+	Confirmation        string
+	Theme               string
+	Language            string
+	Timezone            string
+	EntryDirection      string
+	KeyboardShortcuts   bool
+	ShowShortPagination bool
+	CustomCSS           string
 }
 
 // Merge updates the fields of the given user.
@@ -32,6 +33,7 @@ func (s *SettingsForm) Merge(user *model.User) *model.User {
 	user.Timezone = s.Timezone
 	user.EntryDirection = s.EntryDirection
 	user.KeyboardShortcuts = s.KeyboardShortcuts
+	user.ShowShortPagination = s.ShowShortPagination
 	user.Extra["custom_css"] = s.CustomCSS
 
 	if s.Password != "" {
@@ -68,14 +70,15 @@ func (s *SettingsForm) Validate() error {
 // NewSettingsForm returns a new SettingsForm.
 func NewSettingsForm(r *http.Request) *SettingsForm {
 	return &SettingsForm{
-		Username:          r.FormValue("username"),
-		Password:          r.FormValue("password"),
-		Confirmation:      r.FormValue("confirmation"),
-		Theme:             r.FormValue("theme"),
-		Language:          r.FormValue("language"),
-		Timezone:          r.FormValue("timezone"),
-		EntryDirection:    r.FormValue("entry_direction"),
-		KeyboardShortcuts: r.FormValue("keyboard_shortcuts") == "1",
-		CustomCSS:         r.FormValue("custom_css"),
+		Username:            r.FormValue("username"),
+		Password:            r.FormValue("password"),
+		Confirmation:        r.FormValue("confirmation"),
+		Theme:               r.FormValue("theme"),
+		Language:            r.FormValue("language"),
+		Timezone:            r.FormValue("timezone"),
+		EntryDirection:      r.FormValue("entry_direction"),
+		KeyboardShortcuts:   r.FormValue("keyboard_shortcuts") == "1",
+		ShowShortPagination: r.FormValue("show_short_pagination") == "1",
+		CustomCSS:           r.FormValue("custom_css"),
 	}
 }

--- a/ui/settings_show.go
+++ b/ui/settings_show.go
@@ -27,13 +27,14 @@ func (h *handler) showSettingsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	settingsForm := form.SettingsForm{
-		Username:          user.Username,
-		Theme:             user.Theme,
-		Language:          user.Language,
-		Timezone:          user.Timezone,
-		EntryDirection:    user.EntryDirection,
-		KeyboardShortcuts: user.KeyboardShortcuts,
-		CustomCSS:         user.Extra["custom_css"],
+		Username:            user.Username,
+		Theme:               user.Theme,
+		Language:            user.Language,
+		Timezone:            user.Timezone,
+		EntryDirection:      user.EntryDirection,
+		KeyboardShortcuts:   user.KeyboardShortcuts,
+		ShowShortPagination: user.ShowShortPagination,
+		CustomCSS:           user.Extra["custom_css"],
 	}
 
 	timezones, err := h.store.Timezones()


### PR DESCRIPTION
- Adds a new column to `users` table, `show_short_pagination`
- Adds a new settings form item,`form.prefs.label.show_short_pagination`: 
![image](https://user-images.githubusercontent.com/852873/84718752-56552b00-af2e-11ea-9486-49f7d133ffd5.png)
- If the user enables that option, [this block is always skipped](https://github.com/miniflux/miniflux/commit/667ad638e9548e1975874e476cb64d17004dfd76#diff-ea30c21384683bb4f2dd5e729dc6b5aeR114), top pagination controls are always shown: 
![image](https://user-images.githubusercontent.com/852873/84718872-b2b84a80-af2e-11ea-8ede-587570354d20.png)

-----

- [ ] I have only added the i18n key for English. Unit tests fail because of this. Are there translators available? Are online translation services an acceptable alternative?
- [ ] Is this something acceptable to merge upstream? If not, I can maintain it in my fork. I like it so a `Next` link is always available in one spot.