### PR TITLE
Added CORS support to API. 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,8 +18,10 @@ func Serve(router *mux.Router, store *storage.Storage, pool *worker.Pool, feedHa
 
 	sr := router.PathPrefix("/v1").Subrouter()
 	middleware := newMiddleware(store)
+	sr.Use(middleware.handleCORS)
 	sr.Use(middleware.apiKeyAuth)
 	sr.Use(middleware.basicAuth)
+	sr.Methods("OPTIONS")
 	sr.HandleFunc("/users", handler.createUser).Methods("POST")
 	sr.HandleFunc("/users", handler.users).Methods("GET")
 	sr.HandleFunc("/users/{userID:[0-9]+}", handler.userByID).Methods("GET")

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -21,6 +21,18 @@ type middleware struct {
 func newMiddleware(s *storage.Storage) *middleware {
 	return &middleware{s}
 }
+func (m *middleware) handleCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "X-Auth-Token")
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
 
 func (m *middleware) apiKeyAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Could not make Gorilla's built-in CORS handler work therefore added a simple middleware function to set the required (very permissive) CORS headers and a blank reply to the preflight requests (OPTION).

Closes #675