### PR TITLE
Fix regression: the entire hstore field is replaced when updating settings

### DIFF
--- a/oauth2/profile.go
+++ b/oauth2/profile.go
@@ -16,5 +16,5 @@ type Profile struct {
 }
 
 func (p Profile) String() string {
-	return fmt.Sprintf(`ID=%s ; Username=%s`, p.ID, p.Username)
+	return fmt.Sprintf(`Key=%s ; ID=%s ; Username=%s`, p.Key, p.ID, p.Username)
 }

--- a/storage/user.go
+++ b/storage/user.go
@@ -88,7 +88,7 @@ func (s *Storage) CreateUser(user *model.User) (err error) {
 
 // UpdateExtraField updates an extra field of the given user.
 func (s *Storage) UpdateExtraField(userID int64, field, value string) error {
-	query := fmt.Sprintf(`UPDATE users SET extra = hstore('%s', $1) WHERE id=$2`, field)
+	query := fmt.Sprintf(`UPDATE users SET extra = extra || hstore('%s', $1) WHERE id=$2`, field)
 	_, err := s.db.Exec(query, value, userID)
 	if err != nil {
 		return fmt.Errorf(`store: unable to update user extra field: %v`, err)


### PR DESCRIPTION
This remove keys previously created, for example `google_id`.