### PR TITLE
Display recent entries first in search results

### DIFF
--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -32,7 +32,7 @@ func (e *EntryQueryBuilder) WithSearchQuery(query string) *EntryQueryBuilder {
 		nArgs := len(e.args) + 1
 		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ plainto_tsquery($%d)", nArgs))
 		e.args = append(e.args, query)
-		e.WithOrder(fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d))", nArgs))
+		e.WithOrder(fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - (ln(extract (epoch from now() - published_at)))", nArgs))
 		e.WithDirection("DESC")
 	}
 	return e

--- a/storage/entry_query_builder.go
+++ b/storage/entry_query_builder.go
@@ -32,7 +32,9 @@ func (e *EntryQueryBuilder) WithSearchQuery(query string) *EntryQueryBuilder {
 		nArgs := len(e.args) + 1
 		e.conditions = append(e.conditions, fmt.Sprintf("e.document_vectors @@ plainto_tsquery($%d)", nArgs))
 		e.args = append(e.args, query)
-		e.WithOrder(fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - (ln(extract (epoch from now() - published_at)))", nArgs))
+
+		// 0.0000001 = 0.1 / (seconds_in_a_day)
+		e.WithOrder(fmt.Sprintf("ts_rank(document_vectors, plainto_tsquery($%d)) - extract (epoch from now() - published_at)::float * 0.0000001", nArgs))
 		e.WithDirection("DESC")
 	}
 	return e


### PR DESCRIPTION
When searching often you want to see recent entries, but there are a lot of old articles in results. This PR is attempt to make results for fresh by using published_at in a rank.

closes #397 