### PR TITLE
Make add_invidious_video rule applicable for different invidious instances

### DIFF
--- a/reader/rewrite/rewrite_functions.go
+++ b/reader/rewrite/rewrite_functions.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	youtubeRegex  = regexp.MustCompile(`youtube\.com/watch\?v=(.*)`)
-	invidioRegex  = regexp.MustCompile(`invidio\.us\/watch\?v=(.*)`)
+	invidioRegex  = regexp.MustCompile(`https?:\/\/(.*)\/watch\?v=(.*)`)
 	imgRegex      = regexp.MustCompile(`<img [^>]+>`)
 	textLinkRegex = regexp.MustCompile(`(?mi)(\bhttps?:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])`)
 )
@@ -161,9 +161,8 @@ func addYoutubeVideoUsingInvidiousPlayer(entryURL, entryContent string) string {
 
 func addInvidiousVideo(entryURL, entryContent string) string {
 	matches := invidioRegex.FindStringSubmatch(entryURL)
-	fmt.Println(matches)
-	if len(matches) == 2 {
-		video := `<iframe width="650" height="350" frameborder="0" src="https://invidio.us/embed/` + matches[1] + `" allowfullscreen></iframe>`
+	if len(matches) == 3 {
+		video := `<iframe width="650" height="350" frameborder="0" src="https://` + matches[1] + `/embed/` + matches[2] + `" allowfullscreen></iframe>`
 		return video + `<br>` + entryContent
 	}
 	return entryContent

--- a/reader/sanitizer/sanitizer.go
+++ b/reader/sanitizer/sanitizer.go
@@ -100,7 +100,7 @@ func sanitizeAttributes(baseURL, tagName string, attributes []html.Attribute) ([
 
 		if isExternalResourceAttribute(attribute.Key) {
 			if tagName == "iframe" {
-				if isValidIframeSource(attribute.Val) {
+				if isValidIframeSource(baseURL, attribute.Val) {
 					value = rewriteIframeURL(attribute.Val)
 				} else {
 					continue
@@ -290,7 +290,7 @@ func isBlacklistedResource(src string) bool {
 	return false
 }
 
-func isValidIframeSource(src string) bool {
+func isValidIframeSource(baseURL, src string) bool {
 	whitelist := []string{
 		"https://invidio.us",
 		"//www.youtube.com",
@@ -310,6 +310,11 @@ func isValidIframeSource(src string) bool {
 		"http://bandcamp.com",
 		"https://bandcamp.com",
 		"https://cdn.embedly.com",
+	}
+
+	// allow iframe from same origin
+	if url.Domain(baseURL) == url.Domain(src) {
+		return true
 	}
 
 	for _, prefix := range whitelist {

--- a/reader/sanitizer/sanitizer_test.go
+++ b/reader/sanitizer/sanitizer_test.go
@@ -106,7 +106,7 @@ func TestInvalidNestedTag(t *testing.T) {
 func TestInvalidIFrame(t *testing.T) {
 	input := `<iframe src="http://example.org/"></iframe>`
 	expected := ``
-	output := Sanitize("http://example.org/", input)
+	output := Sanitize("http://example.com/", input)
 
 	if expected != output {
 		t.Errorf(`Wrong output: "%s" != "%s"`, expected, output)


### PR DESCRIPTION
Fixes #641 by constructing invidious embed URL via regex. This change makes it necessary to allow iframes from same origin.