### PR TITLE
handle Pacific Daylight Time in addition to Pacific Standard Time

### DIFF
--- a/reader/date/parser.go
+++ b/reader/date/parser.go
@@ -242,7 +242,7 @@ func parseLocalTimeDates(layout, ds string) (t time.Time, err error) {
 	loc := time.UTC
 
 	// Workaround for dates that don't use GMT.
-	if strings.HasSuffix(ds, "PST") {
+	if strings.HasSuffix(ds, "PST") || strings.HasSuffix(ds, "PDT") {
 		loc, _ = time.LoadLocation("America/Los_Angeles")
 	}
 


### PR DESCRIPTION
Parse "PDT" correctly for feeds in US Pacific time while daylight savings is in effect.